### PR TITLE
Update to launch feature to support device type

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,5 @@ dist
 *.pbxuser
 xcuserdata
 *.xcworkspace
+.idea
+.DS_Store

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,6 @@
 [submodule "lib/KIF"]
 	path = lib/KIF
-	url = https://github.com/square/KIF.git
+	url = git://github.com/square/KIF.git
 [submodule "lib/UISpec"]
 	path = lib/UISpec
-	url = https://github.com/moredip/UISpec
+	url = git://github.com/moredip/UISpec

--- a/gem/frank-skeleton/features/step_definitions/launch_steps.rb
+++ b/gem/frank-skeleton/features/step_definitions/launch_steps.rb
@@ -1,4 +1,4 @@
-Given /^I launch the app$/ do
+Given /^I launch the app in the (iPad|iPhone) simulator$/ do | mode |
 
 
   app_path = ENV['APP_BUNDLE_PATH'] || (defined?(APP_BUNDLE_PATH) && APP_BUNDLE_PATH)
@@ -35,9 +35,9 @@ Given /^I launch the app$/ do
   require 'sim_launcher'
 
   if( ENV['USE_SIM_LAUNCHER_SERVER'] )
-    simulator = SimLauncher::Client.for_iphone_app( app_path )
+    simulator = SimLauncher::Client.send "for_#{mode.downcase}_app", app_path
   else
-    simulator = SimLauncher::DirectClient.for_iphone_app( app_path )
+    simulator = SimLauncher::DirectClient.send "for_#{mode.downcase}_app", app_path
   end
   
   num_timeouts = 0


### PR DESCRIPTION
This modifies the launch steps from the skeleton to take in the device type and use that to start the simulator in the proper mode.
