### PR TITLE
Allow launcher step to specify SDK version

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ dist
 *.perspective
 *.perspectivev3
 xcuserdata
+.rvmrc

--- a/gem/Rakefile
+++ b/gem/Rakefile
@@ -1,4 +1,5 @@
 require 'bundler'
+require 'rake/testtask'
 Bundler::GemHelper.install_tasks
 
 task :edit_version do
@@ -7,3 +8,10 @@ end
 
 task :ev => :edit_version
 
+Rake::TestTask.new do |t|
+  t.libs << "test"
+  t.test_files = FileList['test/*_test.rb','test/*_acceptance.rb']
+  t.verbose = true
+end
+
+task :default => ["test"]

--- a/gem/frank-skeleton/features/step_definitions/launch_steps.rb
+++ b/gem/frank-skeleton/features/step_definitions/launch_steps.rb
@@ -1,4 +1,15 @@
+Given /^I launch the app using iOS (\d.\d)$/ do |version|
+  # You can grab a list of the installed SDK with sim_launcher
+  # > run sim_launcher from the command line
+  # > open a browser to http://localhost:8881/showsdks
+  # > use one of the version you see in parenthesis (e.g. 4.2)
+  launch_app app_path, version
+end
+
 Given /^I launch the app$/ do
-  app_path = ENV['APP_BUNDLE_PATH'] || (defined?(APP_BUNDLE_PATH) && APP_BUNDLE_PATH)
   launch_app app_path
+end
+
+def app_path
+  ENV['APP_BUNDLE_PATH'] || (defined?(APP_BUNDLE_PATH) && APP_BUNDLE_PATH)
 end

--- a/gem/frank-skeleton/features/step_definitions/launch_steps.rb
+++ b/gem/frank-skeleton/features/step_definitions/launch_steps.rb
@@ -1,15 +1,20 @@
-Given /^I launch the app using iOS (\d.\d)$/ do |version|
-  # You can grab a list of the installed SDK with sim_launcher
-  # > run sim_launcher from the command line
-  # > open a browser to http://localhost:8881/showsdks
-  # > use one of the version you see in parenthesis (e.g. 4.2)
-  launch_app app_path, version
+def app_path
+  ENV['APP_BUNDLE_PATH'] || (defined?(APP_BUNDLE_PATH) && APP_BUNDLE_PATH)
 end
 
 Given /^I launch the app$/ do
+  # latest sdk and iphone by default
   launch_app app_path
 end
 
-def app_path
-  ENV['APP_BUNDLE_PATH'] || (defined?(APP_BUNDLE_PATH) && APP_BUNDLE_PATH)
+Given /^I launch the app using iOS (\d\.\d)$/ do |sdk|
+  # You can grab a list of the installed SDK with sim_launcher
+  # > run sim_launcher from the command line
+  # > open a browser to http://localhost:8881/showsdks
+  # > use one of the sdk you see in parenthesis (e.g. 4.2)
+  launch_app app_path, sdk
+end
+
+Given /^I launch the app using iOS (\d\.\d) and the (iphone|ipad) simulator$/ do |sdk, version|
+  launch_app app_path, sdk, version
 end

--- a/gem/lib/frank-cucumber/launcher.rb
+++ b/gem/lib/frank-cucumber/launcher.rb
@@ -2,7 +2,7 @@ module Frank module Cucumber
 
 module Launcher 
   
-  def launch_app(app_path)
+  def launch_app(app_path, sdk=nil)
     if app_path.nil?
       require 'frank-cucumber/app_bundle_locator'
       message = "APP_BUNDLE_PATH is not set. \n\nPlease set APP_BUNDLE_PATH (either an environment variable, or the ruby constant in support/env.rb) to the path of your Frankified target's iOS app bundle."
@@ -26,11 +26,12 @@ module Launcher
 
 
     require 'sim_launcher'
+    puts "app_path #{app_path}"
 
     if( ENV['USE_SIM_LAUNCHER_SERVER'] )
-      simulator = SimLauncher::Client.for_iphone_app( app_path )
+      simulator = SimLauncher::Client.for_iphone_app( app_path, sdk )
     else
-      simulator = SimLauncher::DirectClient.for_iphone_app( app_path )
+      simulator = SimLauncher::DirectClient.for_iphone_app( app_path, sdk )
     end
 
     num_timeouts = 0

--- a/gem/test/launcher_test.rb
+++ b/gem/test/launcher_test.rb
@@ -1,0 +1,43 @@
+require_relative 'test_helper.rb'
+
+def wait_for_frank_to_come_up
+  # orig FrankHelper::wait_for_frank_to_come_up
+  # doing nothing
+end
+
+describe "frank cucumber launcher" do
+
+  describe "when the path is wrong" do
+  
+    it 'throws exception when no app path is given' do
+      assert_raises(RuntimeError) do
+        enforce(nil)
+      end
+    end
+
+    it 'prints suggestions if available' do
+        mock_locator = Mock.new
+        mock_locator.expect :guess_possible_app_bundles_for_dir, ['suggestion_1'], ['']
+        begin
+          enforce(nil, mock_locator)
+        rescue RuntimeError => e
+          e.message.must_match "suggestion_1"
+        end
+    end
+  end
+
+  describe "when starting the simulator with the specified params" do
+
+    before do
+      @simulator_direct_client = Mock.new 
+      @simulator_direct_client.expect :relaunch, nil, [] 
+    end
+    
+    it 'selects iphone mode by default' do
+      launch_app('test_path', 'X.Y')
+      @version.must_equal 'iphone'
+    end
+
+  end
+
+end

--- a/gem/test/test_helper.rb
+++ b/gem/test/test_helper.rb
@@ -1,0 +1,10 @@
+require 'stringio'
+require 'minitest/autorun'
+require 'minitest/mock'
+require 'minitest/spec'
+include MiniTest
+require_relative '../lib/frank-cucumber/color_helper'
+require_relative '../lib/frank-cucumber/frank_helper'
+require_relative '../lib/frank-cucumber/launcher'
+include Frank::Cucumber::Launcher
+include Frank::Cucumber::FrankHelper


### PR DESCRIPTION
Hi,

I just added one more optional parameter to specify the target SDK to run in the simulator. I also added a skeleton step that makes use of the version so you can write something like "Given I launch the app using iOS 4.2".
