### PR TITLE
Fixed WAIT_TIMEOUT environment variable casting issue

### DIFF
--- a/gem/lib/frank-cucumber/core_frank_steps.rb
+++ b/gem/lib/frank-cucumber/core_frank_steps.rb
@@ -1,4 +1,4 @@
-WAIT_TIMEOUT = ENV['WAIT_TIMEOUT'] || 240
+WAIT_TIMEOUT = ENV['WAIT_TIMEOUT'].to_i || 240
 
 require 'rspec/expectations'
 


### PR DESCRIPTION
I've encountered an error when I tried to set `WAIT_TIMEOUT` from command line or `env.rb`:

```
undefined method `zero?' for "3.0":String (NoMethodError)
  /System/Library/Frameworks/Ruby.framework/Versions/1.8/usr/lib/ruby/1.8/timeout.rb:53:in `timeout'
```

I've found casting `ENV['WAIT_TIMEOUT'].to_i` solves the problem, but I'm not a rubist, so my solution may be wrong. Please review it closely. 

Here's my system configuration:
- `Mac OS X 10.7.2`
- `ruby 1.8.7 (2010-01-10 patchlevel 249) [universal-darwin11.0]`
- `cucumber 1.1.4`
- `frank-cucumber 0.8.7`
