### PR TITLE
Frank is not working with an operating system not using English as system language

### DIFF
--- a/gem/frank-cucumber.gemspec
+++ b/gem/frank-cucumber.gemspec
@@ -20,6 +20,7 @@ Gem::Specification.new do |s|
   s.add_dependency( "cucumber" )
   s.add_dependency( "rspec", [">=2.0"] )
   s.add_dependency( "sim_launcher" )
+  s.add_dependency( "i18n" )
   s.add_dependency( "plist" )
   s.add_dependency( "json" ) # TODO: figure out how to be more permissive as to which JSON gems we allow
 end

--- a/gem/lib/frank-cucumber/frank_helper.rb
+++ b/gem/lib/frank-cucumber/frank_helper.rb
@@ -1,4 +1,3 @@
-# encoding: utf-8
 require 'net/http'
 require 'json'
 require 'frank-cucumber/frank_localize'

--- a/gem/lib/frank-cucumber/frank_helper.rb
+++ b/gem/lib/frank-cucumber/frank_helper.rb
@@ -1,5 +1,7 @@
+# encoding: utf-8
 require 'net/http'
 require 'json'
+require 'frank-cucumber/frank_localize'
 
 module Frank module Cucumber
 
@@ -219,37 +221,38 @@ module FrankHelper
     %x{osascript<<APPLESCRIPT
 activate application "iPhone Simulator"
 tell application "System Events"
-	click menu item "#{menu_label}" of menu "Hardware" of menu bar of process "iPhone Simulator"
+	click menu item "#{menu_label}" of menu "#{Localize.t(:hardware)}" of menu bar of process "#{Localize.t(:iphone_simulator)}"
 end tell
   APPLESCRIPT}  
   end
   
   def press_home_on_simulator
-    simulator_hardware_menu_press "Home"
+  puts I18n.t(:rotate_left)
+    simulator_hardware_menu_press Localize.t(:home)
   end
   
   def rotate_simulator_left
-    simulator_hardware_menu_press "Rotate Left"
+    simulator_hardware_menu_press Localize.t(:rotate_left)
   end
 
   def rotate_simulator_right
-    simulator_hardware_menu_press "Rotate Right"
+    simulator_hardware_menu_press Localize.t(:rotate_right)
   end
 
   def shake_simulator
-    simulator_hardware_menu_press "Shake Gesture"
+    simulator_hardware_menu_press Localize.t(:shake_gesture)
   end
   
   def simulate_memory_warning
-    simulator_hardware_menu_press "Simulate Memory Warning"
+    simulator_hardware_menu_press Localize.t(:simulate_memory_warning)
   end
   
   def toggle_call_status_bar
-    simulator_hardware_menu_press "Toggle In-Call Status Bar"
+    simulator_hardware_menu_press Localize.t(:toggle_call_status_bar)
   end
   
   def simulate_hardware_keyboard
-    simulator_hardware_menu_press "Simulate Hardware Keyboard"
+    simulator_hardware_menu_press Localize.t(:simulate_hardware_keyboard)
   end
 end
 

--- a/gem/lib/frank-cucumber/frank_helper.rb
+++ b/gem/lib/frank-cucumber/frank_helper.rb
@@ -226,7 +226,6 @@ end tell
   end
   
   def press_home_on_simulator
-  puts I18n.t(:rotate_left)
     simulator_hardware_menu_press Localize.t(:home)
   end
   

--- a/gem/lib/frank-cucumber/frank_localize.rb
+++ b/gem/lib/frank-cucumber/frank_localize.rb
@@ -1,0 +1,31 @@
+require 'i18n'
+
+module Frank
+  module Cucumber
+    module Localize
+
+      def self.system_locale
+        case ENV['LANG']
+        when /^fr_/
+          :fr
+        else
+          :en
+        end
+      end
+
+      def self.load_translations
+        if I18n.backend.send(:translations).size == 0
+          I18n.locale = self.system_locale
+          I18n.load_path = [ File.join(File.dirname(__FILE__), 'localize.yml') ]
+          I18n.backend.load_translations
+        end
+      end
+
+      def self.t(key)
+        self.load_translations
+        I18n.t(key)
+      end
+
+    end
+  end
+end

--- a/gem/lib/frank-cucumber/localize.yml
+++ b/gem/lib/frank-cucumber/localize.yml
@@ -1,0 +1,21 @@
+en:
+  iphone_simulator: iPhone Simulator
+  hardware: Hardware
+  home: Home
+  rotate_left: Rotate Left
+  rotate_right: Rotate Right
+  shake_gesture: Shake Gesture
+  simulate_memory_warning: Simulate Memory Warning
+  toggle_in_call_status_bar: Toggle In-Call Status Bar
+  simulate_hardware_keyboard: Simulate Hardware Keyboard
+
+fr:
+  iphone_simulator: Simulateur iOS
+  hardware: Matériel
+  home: Écran d’accueil
+  rotate_left: Rotation à gauche
+  rotate_right: Rotation à droite
+  shake_gesture: Secousse
+  simulate_memory_warning: Simuler un avertissement de mémoire
+  toggle_in_call_status_bar: Afficher/Masquer la barre d'état d'appel en cour
+  simulate_hardware_keyboard: Simuler un clavier matériel


### PR DESCRIPTION
Hello,

When trying to run a feature, I got the following error:

71:158: execution error: System Events got an error: Can’t get menu "Hardware" of menu bar of process "iPhone Simulator". (-1728)

The reason is that my MacOS uses French as system language, and instead of "iPhone Simulator", Franck should use "Simulateur iOS"...
It means that Frank needs to be aware of OS language to choose the correct words (at least when calling the AppleScript scripts).

I fixed the issue, I used i18n. That's pretty simple.
The default locale is english, I added only support for french language, but this is easy to add support for a new language, ie update the file localize.yml
