### PR TITLE
Alert View step ammends

### DIFF
--- a/gem/lib/frank-cucumber/core_frank_steps.rb
+++ b/gem/lib/frank-cucumber/core_frank_steps.rb
@@ -71,10 +71,27 @@ Then /^I should see a navigation bar titled "([^\"]*)"$/ do |expected_mark|
   values.should include(expected_mark)
 end
 
-Then /^I should see an alert view titled "([^\"]*)"$/ do |expected_mark|
-  values = frankly_map( 'alertView', 'message')
-  puts values
-  values.should include(expected_mark)
+Then /^I should (not )?see an alert view with title "([^\"]*)"$/ do |qualifier, expected_mark|
+    expected_to_see = "not " != qualifier
+    values = frankly_map( 'alertView', 'title')
+    puts values
+    if expected_to_see
+        values.should include(expected_mark)
+        else
+        values.should_not include(expected_mark)
+    end
+    
+end
+
+Then /^I should (not )?see an alert view with message "([^\"]*)"$/ do |qualifier, expected_mark|
+    expected_to_see = "not " != qualifier
+    values = frankly_map( 'alertView', 'message')
+    puts values
+    if expected_to_see
+        values.should include(expected_mark)
+        else
+        values.should_not include(expected_mark)
+    end
 end
 
 Then /^I should not see an alert view$/ do
@@ -231,6 +248,10 @@ end
 When /^I touch the (\d*)(?:st|nd|rd|th)? alert view button$/ do |ordinal|
   ordinal = ordinal.to_i
   touch( "alertView threePartButton tag:#{ordinal}" )
+end
+
+When /^I touch the alert view button marked "([^\"]*)"$/ do |mark|
+    touch( "alertView button marked:'#{mark}'" )
 end
 
 # -- switch -- #


### PR DESCRIPTION
[~] FIX: alert view with title now checking title field rather than
message
[+] ADD: alert view with message
[~] MOD: NOT param added to alert view with title/message
[+] ADD: alert view with button title (for iOS5 which has different
alertView implementation)
