### PR TITLE
iOS Simulator reset of contents and settings and german localization of the simulator

### DIFF
--- a/gem/lib/frank-cucumber/core_frank_steps.rb
+++ b/gem/lib/frank-cucumber/core_frank_steps.rb
@@ -276,3 +276,7 @@ end
 When /^I quit the simulator/ do
   quit_simulator 
 end
+
+When /^I reset the simulator/ do
+  simulator_reset_data
+end

--- a/gem/lib/frank-cucumber/frank_helper.rb
+++ b/gem/lib/frank-cucumber/frank_helper.rb
@@ -214,6 +214,17 @@ module FrankHelper
     APPLESCRIPT}
   end
 
+def simulator_reset_data
+  %x{osascript<<APPLESCRIPT
+activate application "iPhone Simulator"
+tell application "System Events"
+  click menu item "#{Localize.t(:reset_contents)}" of menu "#{Localize.t(:iphone_simulator)}" of menu bar of process "#{Localize.t(:iphone_simulator)}"
+  delay 0.5
+  keystroke space
+end tell
+  APPLESCRIPT} 
+end
+
   #Note this needs to have "Enable access for assistive devices"
   #chcked in the Universal Access system preferences
   def simulator_hardware_menu_press( menu_label )

--- a/gem/lib/frank-cucumber/frank_helper.rb
+++ b/gem/lib/frank-cucumber/frank_helper.rb
@@ -218,9 +218,9 @@ def simulator_reset_data
   %x{osascript<<APPLESCRIPT
 activate application "iPhone Simulator"
 tell application "System Events"
-  click menu item "#{Localize.t(:reset_contents)}" of menu "#{Localize.t(:iphone_simulator)}" of menu bar of process "#{Localize.t(:iphone_simulator)}"
+  click menu item 5 of menu 1 of menu bar item 2 of menu bar 1 of process "#{Localize.t(:iphone_simulator)}"
   delay 0.5
-  keystroke space
+  click button 2 of window 1 of process "#{Localize.t(:iphone_simulator)}"
 end tell
   APPLESCRIPT} 
 end

--- a/gem/lib/frank-cucumber/frank_localize.rb
+++ b/gem/lib/frank-cucumber/frank_localize.rb
@@ -8,6 +8,8 @@ module Frank
         case ENV['LANG']
         when /^fr_/
           :fr
+        when /^de_/
+          :de
         else
           :en
         end

--- a/gem/lib/frank-cucumber/localize.yml
+++ b/gem/lib/frank-cucumber/localize.yml
@@ -8,6 +8,7 @@ en:
   simulate_memory_warning: Simulate Memory Warning
   toggle_in_call_status_bar: Toggle In-Call Status Bar
   simulate_hardware_keyboard: Simulate Hardware Keyboard
+  reset_contents: Reset Content and Settings...
 
 fr:
   iphone_simulator: Simulateur iOS
@@ -30,3 +31,4 @@ de:
   simulate_memory_warning: Speicherwarnhinweis simulieren
   toggle_in_call_status_bar: Status für eingeh. Anrufe ein/aus
   simulate_hardware_keyboard: Hardware-Tastatur simulieren
+  reset_contents: Inhalte und Einstellungen zurücksetzen …

--- a/gem/lib/frank-cucumber/localize.yml
+++ b/gem/lib/frank-cucumber/localize.yml
@@ -8,7 +8,6 @@ en:
   simulate_memory_warning: Simulate Memory Warning
   toggle_in_call_status_bar: Toggle In-Call Status Bar
   simulate_hardware_keyboard: Simulate Hardware Keyboard
-  reset_contents: Reset Content and Settings...
 
 fr:
   iphone_simulator: Simulateur iOS
@@ -31,4 +30,3 @@ de:
   simulate_memory_warning: Speicherwarnhinweis simulieren
   toggle_in_call_status_bar: Status für eingeh. Anrufe ein/aus
   simulate_hardware_keyboard: Hardware-Tastatur simulieren
-  reset_contents: Inhalte und Einstellungen zurücksetzen …

--- a/gem/lib/frank-cucumber/localize.yml
+++ b/gem/lib/frank-cucumber/localize.yml
@@ -19,3 +19,14 @@ fr:
   simulate_memory_warning: Simuler un avertissement de mémoire
   toggle_in_call_status_bar: Afficher/Masquer la barre d'état d'appel en cour
   simulate_hardware_keyboard: Simuler un clavier matériel
+
+de:
+  iphone_simulator: iOS-Simulator
+  hardware: Hardware
+  home: Home
+  rotate_left: Links drehen
+  rotate_right: Rechts drehen
+  shake_gesture: Schüttelgeste
+  simulate_memory_warning: Speicherwarnhinweis simulieren
+  toggle_in_call_status_bar: Status für eingeh. Anrufe ein/aus
+  simulate_hardware_keyboard: Hardware-Tastatur simulieren


### PR DESCRIPTION
I Added a step to reset the contents and settings of the iOS Simulator. The step is invoked via AppleScript, similar to the Hardware menu buttons and does not require localized strings.

Extending Pull Request 63 ( https://github.com/moredip/Frank/pull/63 ) I added german localization to make the simulator hardware commands work on german systems
