### PR TITLE
Updated View serialization code

### DIFF
--- a/Frank.xcodeproj/project.pbxproj
+++ b/Frank.xcodeproj/project.pbxproj
@@ -7,6 +7,8 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		0071264614F8956700E738ED /* ViewJSONSerializer.h in Headers */ = {isa = PBXBuildFile; fileRef = 0071264414F8956700E738ED /* ViewJSONSerializer.h */; };
+		0071264714F8956700E738ED /* ViewJSONSerializer.m in Sources */ = {isa = PBXBuildFile; fileRef = 0071264514F8956700E738ED /* ViewJSONSerializer.m */; };
 		4C1DD76C12BADFE100E10B8C /* OrientationCommand.m in Sources */ = {isa = PBXBuildFile; fileRef = 4C1DD76812BADFE100E10B8C /* OrientationCommand.m */; };
 		4C1DD76D12BADFE100E10B8C /* OrientationCommand.h in Headers */ = {isa = PBXBuildFile; fileRef = 4C1DD76912BADFE100E10B8C /* OrientationCommand.h */; };
 		4C1DD76E12BADFE100E10B8C /* AppCommand.m in Sources */ = {isa = PBXBuildFile; fileRef = 4C1DD76A12BADFE100E10B8C /* AppCommand.m */; };
@@ -152,6 +154,8 @@
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
+		0071264414F8956700E738ED /* ViewJSONSerializer.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = ViewJSONSerializer.h; path = src/ViewJSONSerializer.h; sourceTree = "<group>"; };
+		0071264514F8956700E738ED /* ViewJSONSerializer.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = ViewJSONSerializer.m; path = src/ViewJSONSerializer.m; sourceTree = "<group>"; };
 		4C1DD76812BADFE100E10B8C /* OrientationCommand.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = OrientationCommand.m; path = src/OrientationCommand.m; sourceTree = "<group>"; };
 		4C1DD76912BADFE100E10B8C /* OrientationCommand.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = OrientationCommand.h; path = src/OrientationCommand.h; sourceTree = "<group>"; };
 		4C1DD76A12BADFE100E10B8C /* AppCommand.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = AppCommand.m; path = src/AppCommand.m; sourceTree = "<group>"; };
@@ -380,6 +384,8 @@
 				D6BD521D146C34BF001770B1 /* SelectorEngineRegistry.m */,
 				D6BD5220146C36A3001770B1 /* UIQuerySelectorEngine.h */,
 				D6BD5221146C36A3001770B1 /* UIQuerySelectorEngine.m */,
+				0071264414F8956700E738ED /* ViewJSONSerializer.h */,
+				0071264514F8956700E738ED /* ViewJSONSerializer.m */,
 			);
 			name = src;
 			sourceTree = "<group>";
@@ -649,6 +655,7 @@
 				D6325EE21437F7180057330D /* UIProxy.h in Headers */,
 				D6325EE41437F7180057330D /* WaitUntilIdle.h in Headers */,
 				D6BD5222146C36A3001770B1 /* UIQuerySelectorEngine.h in Headers */,
+				0071264614F8956700E738ED /* ViewJSONSerializer.h in Headers */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -786,6 +793,7 @@
 				D6B1056114644827000DD32F /* UIQuery+ShelleyCompatibiilityOverrides.m in Sources */,
 				D6BD521F146C34BF001770B1 /* SelectorEngineRegistry.m in Sources */,
 				D6BD5223146C36A3001770B1 /* UIQuerySelectorEngine.m in Sources */,
+				0071264714F8956700E738ED /* ViewJSONSerializer.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/frank_static_resources.bundle/ViewAttributeMapping.plist
+++ b/frank_static_resources.bundle/ViewAttributeMapping.plist
@@ -1,0 +1,62 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>UIView</key>
+	<array>
+		<string>accessibilityLabel</string>
+		<string>accessibilityFrame</string>
+		<string>alpha</string>
+		<string>autoresizingMask</string>
+		<string>backgroundColor</string>
+		<string>frame</string>
+		<string>isHidden</string>
+	</array>
+    <key>UIWindow</key>
+	<array>
+		<string>windowLevel</string>
+		<string>isKeyWindow</string>
+	</array>
+	<key>UIScrollView</key>
+	<array>
+		<string>contentOffset</string>
+		<string>contentSize</string>
+		<string>isScrollEnabled</string>
+		<string>contentInset</string>
+		<string>isPagingEnabled</string>
+		<string>bounces</string>
+		<string>alwaysBounceVertical</string>
+		<string>alwaysBounceHorizontal</string>
+		<string>showsHorizontalScrollIndicator</string>
+		<string>showsVerticalScrollIndicator</string>
+		<string>zoomScale</string>
+		<string>maximumZoomScale</string>
+		<string>minimumZoomScale</string>
+		<string>delegate</string>
+	</array>
+	<key>UITableView</key>
+	<array>
+		<string>dataSource</string>
+	</array>
+	<key>UILabel</key>
+	<array>
+		<string>text</string>
+		<string>font</string>
+		<string>textAlignment</string>
+	</array>
+	<key>UISegmentedControl</key>
+	<array>
+		<string>segmentedControlStyle</string>
+		<string>numberOfSegments</string>
+		<string>selectedSegmentIndex</string>
+	</array>
+	<key>MKMapView</key>
+	<array>
+		<string>mapType</string>
+		<string>isZoomEnabled</string>
+		<string>isScrollEnabled</string>
+		<string>userTrackingMode</string>
+		<string>delegate</string>
+	</array>
+</dict>
+</plist>

--- a/lib/cocoahttpserver/HTTPConnection.m
+++ b/lib/cocoahttpserver/HTTPConnection.m
@@ -47,6 +47,8 @@
 #define HTTP_RESPONSE                      30
 #define HTTP_FINAL_RESPONSE                45
 
+extern BOOL frankLogEnabled;
+
 // A quick note about the tags:
 // 
 // The HTTP_RESPONSE and HTTP_FINAL_RESPONSE are designated tags signalling that the response is completely sent.
@@ -1043,8 +1045,9 @@ static NSMutableArray *recentNonces;
 	// Override me for custom error handling of 404 not found responses
 	// If you simply want to add a few extra header fields, see the preprocessErrorResponse: method.
 	// You can also use preprocessErrorResponse: to add an optional HTML body.
-	
-	NSLog(@"HTTP Server: Error 404 - Not Found");
+	if(frankLogEnabled) {
+        NSLog(@"HTTP Server: Error 404 - Not Found");
+    }
 	
 	// Status Code 404 - Not Found
 	CFHTTPMessageRef response = CFHTTPMessageCreateResponse(kCFAllocatorDefault, 404, NULL, kCFHTTPVersion1_1);

--- a/src/DumpCommand.h
+++ b/src/DumpCommand.h
@@ -14,6 +14,4 @@
     NSMutableDictionary *classMapping;
 }
 
-+ (NSObject *) jsonify: (id<NSObject>) obj;
-
 @end

--- a/src/DumpCommand.h
+++ b/src/DumpCommand.h
@@ -11,9 +11,9 @@
 #import "FrankCommandRoute.h"
 
 @interface DumpCommand : NSObject<FrankCommand> {
-
+    NSMutableDictionary *classMapping;
 }
 
-+ (NSObject *) jsonify:(id) obj;
++ (NSObject *) jsonify: (id<NSObject>) obj;
 
 @end

--- a/src/DumpCommand.m
+++ b/src/DumpCommand.m
@@ -13,8 +13,6 @@
 #import "UIQuery.h"
 #import "JSON.h"
 
-static NSArray *skippedClasses;
-
 @interface DumpCommand()
 @property (nonatomic, readwrite, retain) NSMutableDictionary *classMapping;
 
@@ -32,17 +30,7 @@ static NSArray *skippedClasses;
 
 - (id) init {
     self = [super init];
-    if(self) {
-        
-        static dispatch_once_t onceToken;
-        dispatch_once(&onceToken, ^{
-            // so far, the only class I've found that can't properly be serialized
-            // Using NSClassFromString to avoid import and pulling all of CoreAnimation
-            skippedClasses = [[NSArray alloc] initWithObjects: NSClassFromString(@"CALayer"), 
-                                NSClassFromString(@"UIWindowLayer"),
-                                NSClassFromString(@"MKMapView"), nil];
-        });
-        
+    if(self) {        
         // eye ball this guy to about 15 classes.
         self.classMapping = [NSMutableDictionary dictionaryWithCapacity: 15];
         [self loadClassMapping];
@@ -129,20 +117,6 @@ static NSArray *skippedClasses;
             
             // just skip nil values, we don't want to pollute the JSON tree with bullshitty empty values
             if(value == nil) {
-                continue;
-            }
-            
-            // make sure we're not trying to return a field that should be skipped
-            BOOL shouldContinue = NO;
-            // we HAVE to go through all classes, -contains: value.class won't work since we could
-            // get a subclass and equality will just return NO when we want to skip the value.
-            for(Class clazz in skippedClasses) {
-                if([value isKindOfClass: clazz]) {
-                    shouldContinue = YES;
-                    break;
-                }
-            }
-            if (shouldContinue) {
                 continue;
             }
             

--- a/src/DumpCommand.m
+++ b/src/DumpCommand.m
@@ -190,6 +190,16 @@ static NSArray *skippedClasses;
         value = [DumpCommand extractInstanceFromValue: (NSValue *) value];
     }
     
+    // at this point, we want only NSNumbers, NSArray, NSDictionary, NSString or NSNull,
+    if(![value isKindOfClass: NSNumber.class] && 
+        ![value isKindOfClass: NSString.class] && 
+        ![value isKindOfClass: NSArray.class] &&    
+        ![value isKindOfClass: NSDictionary.class] && 
+        ![value isKindOfClass: NSNull.class] &&
+        value != nil) {
+        return [NSString stringWithFormat:@"<%@ @%i>", [value class], value];
+    }
+    
     return value;
 }
 

--- a/src/DumpCommand.m
+++ b/src/DumpCommand.m
@@ -13,299 +13,320 @@
 #import "UIQuery.h"
 #import "JSON.h"
 
-NSMutableDictionary *convertViewDescriptionToJson( NSDictionary *dictionary ) {
-	NSMutableDictionary *convertedDictionary = [NSMutableDictionary dictionaryWithCapacity:[dictionary count]];
-	for(id key in [dictionary allKeys]) {
-		id value = [dictionary valueForKey:key];
-		[convertedDictionary setObject:[DumpCommand jsonify:value] forKey:key];
-	}
-	return convertedDictionary;
-}
+static NSArray *skippedClasses;
 
-NSDictionary *customAttributesFor( UIView *view ) {
-	NSMutableDictionary *customAttributes = [NSMutableDictionary dictionary];
-	
-	if( [view respondsToSelector:@selector(accessibilityLabel)] )
-	{
-		id value = [view accessibilityLabel];
-		if( !value )
-			value = [NSNull null];
-		[customAttributes setObject:value forKey:@"accessibilityLabel"];
-	}
-	
-	[customAttributes setObject:NSStringFromClass([view class]) forKey:@"class"];
-	[customAttributes setObject:[NSNumber numberWithFloat:[view alpha]]  forKey:@"alpha"];
-	[customAttributes setObject:[NSNumber numberWithBool:[view isOpaque]]  forKey:@"isOpaque"];
-	[customAttributes setObject:[NSNumber numberWithBool:[view isHidden]]  forKey:@"isHidden"];
-	[customAttributes setObject:[DumpCommand jsonify:[view backgroundColor]] forKey:@"backgroundColor"];
-    
-	return customAttributes;
-}
+@interface DumpCommand()
+@property (nonatomic, readwrite, retain) NSMutableDictionary *classMapping;
 
-NSDictionary *mapObjectToPropertiesDictionary( NSObject *object ) {
-	// Based on UIQuery#describe from UISpec codebase
-    
-	NSMutableDictionary *properties = [NSMutableDictionary dictionary];
-	Class clazz = [object class];
-	do {
-		unsigned i;
-		id objValue;
-		int intValue;
-        unsigned int uintValue;
-		long longValue;
-        long long longlongValue;
-		char *charPtrValue; 
-		unsigned char charValue;
-		short shortValue;
-		float floatValue;
-		double doubleValue;
-		
-		uint propertyCount = 0;
-		objc_property_t *propertyList = class_copyPropertyList(clazz, &propertyCount);
-		//NSLog(@"%@ property count = %d", clazz, propertyCount);
-		for (i=0; i<propertyCount; i++) {
-			objc_property_t *thisProperty = propertyList + i;
-			const char* propertyName = property_getName(*thisProperty);
-			const char* propertyAttributes = property_getAttributes(*thisProperty);
-			
-			NSString *key = [NSString stringWithFormat:@"%s", propertyName];
-			NSString *keyAttributes = [NSString stringWithFormat:@"%s", propertyAttributes];
-			
-			NSArray *attributes = [keyAttributes componentsSeparatedByString:@","];
-			if ([[[attributes lastObject] substringToIndex:1] isEqualToString:@"G"]) {
-				key = [[attributes lastObject] substringFromIndex:1];
-			}
-			
-			SEL selector = NSSelectorFromString(key);
-			if ([object respondsToSelector:selector] && [key characterAtIndex: 0] != '_') {
-				NSMethodSignature *sig = [object methodSignatureForSelector:selector];
-				//NSLog(@"sig = %@", sig);
-				NSInvocation *invocation = [NSInvocation invocationWithMethodSignature:sig];
-				[invocation setSelector:selector];
-				//NSLog(@"invocation selector = %@", NSStringFromSelector([invocation selector]));
-				[invocation setTarget:object];
-				
-				@try {
-					[invocation invoke];
-				}
-				@catch (NSException *exception) {
-					NSLog(@"DumpCommand.mapObjectToPropertiesDictionary caught %@: %@", [exception name], [exception reason]);
-					continue;
-				}
-				
-				const char* type = [[invocation methodSignature] methodReturnType];
-				NSString *returnType = [NSString stringWithFormat:@"%s", type];
-				const char* trimmedType = [[returnType substringToIndex:1] cStringUsingEncoding:NSASCIIStringEncoding];
-                
-				//NSLog(@"return values - type: %@", returnType);
-				
-				switch(*trimmedType) {
-					case '@':
-						[invocation getReturnValue:(void **)&objValue];
-						if (objValue == nil) {
-							[properties setObject:[NSNull null] forKey:key];
-						} else {
-							[properties setObject:objValue forKey:key];
-						}
-						break;
-					case 'i':
-						[invocation getReturnValue:(void **)&intValue];
-						[properties setObject:[NSNumber	numberWithInt:intValue] forKey:key];
-						break;
-                    case 'I':
-						[invocation getReturnValue:(void **)&uintValue];
-						[properties setObject:[NSNumber	numberWithUnsignedInt:uintValue] forKey:key];                        
-					case 's':
-						[invocation getReturnValue:(void **)&shortValue];
-						[properties setObject:[NSNumber	numberWithShort:shortValue] forKey:key];
-						break;
-					case 'd':
-						[invocation getReturnValue:(void **)&doubleValue];
-						[properties setObject:[NSNumber	numberWithDouble:doubleValue] forKey:key];
-						break;
-					case 'f':
-						[invocation getReturnValue:(void **)&floatValue];
-						[properties setObject:[NSNumber	numberWithFloat:floatValue] forKey:key];
-						break;
-					case 'l':
-						[invocation getReturnValue:(void **)&longValue];
-						[properties setObject:[NSNumber	numberWithLong:longValue] forKey:key];
-						break;
-					case 'Q':
-						[invocation getReturnValue:(void **)&longlongValue];
-						[properties setObject:[NSNumber	numberWithLongLong:longlongValue] forKey:key];
-						break;
-					case '*':
-						[invocation getReturnValue:(void **)&charPtrValue];
-						[properties setObject:[NSString stringWithFormat:@"%s", charPtrValue] forKey:key];
-						break;
-					case 'c':
-						[invocation getReturnValue:(void **)&charValue];
-						
-						// if the property is an unsigned char of 0 or 1 then it's almost certainly a BOOL type
-						if( charValue < 2 )
-							[properties setObject:[NSNumber	numberWithBool:charValue] forKey:key];
-						else {
-							[properties setObject:[NSNumber	numberWithUnsignedChar:charValue] forKey:key];
-						}
-                        
-						break;
-					case '{': {
-                        // find the first equals symbol in there
-                        NSRange firstEqualsPosition = [returnType rangeOfString:@"="];
-                        // it's not found, we have no clue what this value is, keep on moving
-                        if(firstEqualsPosition.location == NSNotFound) {
-                            continue;
-                        }
-                        // extract the string between { and =
-                        NSRange theRange;
-                        theRange.location = 1;
-                        theRange.length = firstEqualsPosition.location - 1;
-                        NSString *concreteCType = [returnType substringWithRange: theRange];
-                        
-                        // this is not a CGRect, keep on moving
-                        if([concreteCType caseInsensitiveCompare: @"CGRect"] != NSOrderedSame) {
-                            continue;
-                        }
-                        
-						unsigned int length = [[invocation methodSignature] methodReturnLength];
-						void *buffer = (void *)malloc(length);
-						[invocation getReturnValue:buffer];
-						NSValue *value = [[[NSValue alloc] initWithBytes:buffer objCType:type] autorelease]; 
-                        if( CGRectEqualToRect([value CGRectValue],CGRectZero )) {
-                            NSLog(@"error, no accessibilityFrame");
-                            UIView *tmpView = (UIView *)object;
-                            NSLog(@"frame %@, accessabilityFrame %@", NSStringFromCGRect([tmpView frame]), NSStringFromCGRect([tmpView accessibilityFrame]));
-                            
-                            value = [NSValue valueWithCGRect: [tmpView frame]];
-                        }
-                        [properties setObject:value forKey:key];
-						break;
-					}
-					default: {
-						NSLog(@"Unrecognized return type: %@", returnType);
-					}
-						
-				}
-			}
-		}
-	} while ((clazz = class_getSuperclass(clazz)) != nil);
-	//NSLog(@"%@ properties: %@", object, [properties debugDescription]);
-    return properties;
-}
+// extracting classes, will end up in a proper static class to avoid weird dependencies
++ (id) extractInstanceFromValue: (NSValue *) value;
++ (id) extractInstanceFromColor: (UIColor *) color;
++ (id) extractInstanceFromFont: (UIFont *) font;
 
-NSDictionary *describeView( UIView *view ) {
-	NSMutableArray *subviewDescriptions = [NSMutableArray array];
-	for (UIView *subview in view.subviews) {
-		[subviewDescriptions addObject: describeView(subview) ];
-	}
-	
-	NSMutableDictionary *description = [NSMutableDictionary dictionaryWithDictionary:mapObjectToPropertiesDictionary(view)];
-	description = convertViewDescriptionToJson(description);
-	[description setObject:subviewDescriptions forKey:@"subviews"];
-	[description addEntriesFromDictionary:customAttributesFor(view)];
-	
-	return description;
-}
+- (NSDictionary *) serializeView: (UIView *) view;
+- (id) valueForAttribute: (NSString *) attribute onObject: (NSObject *) object;
+- (void) loadClassMapping;
+@end
 
-NSObject *jsonifyValue(NSValue *val) {
-	if( !strcmp([val objCType], @encode(CGFloat)) ) 
-	{
-		float floatVal;
-		[val getValue:&floatVal];
-		return [NSNumber numberWithFloat:floatVal];
-	}
-	
-	if( [val objCType][0] == '{' ){ //NSValue type
-		NSString *typeString = [NSString stringWithFormat:@"%s", [val objCType]+1]; //we use +1 to skip past the {
-		
-		NSString *valueType = [[typeString componentsSeparatedByString:@"="] objectAtIndex:0];
+@implementation DumpCommand
+
+- (id) init {
+    self = [super init];
+    if(self) {
         
-		if( [valueType isEqualToString:@"CGSize"] ){
-			CGSize rawSize;
-			[val getValue:&rawSize];
-			return [NSDictionary dictionaryWithObjectsAndKeys:
-					[NSNumber numberWithFloat:rawSize.width], @"width",
-					[NSNumber numberWithFloat:rawSize.height], @"height",
-					nil];
-		}
-		
-		if( [valueType isEqualToString:@"CGRect"] ){
-			CGRect rawRect;
-			[val getValue:&rawRect];
-			NSDictionary *originDict = [NSDictionary dictionaryWithObjectsAndKeys:
-                                        [NSNumber numberWithFloat:rawRect.origin.x], @"x",
-                                        [NSNumber numberWithFloat:rawRect.origin.y], @"y",
-                                        nil];
-			NSDictionary *sizeDict = [NSDictionary dictionaryWithObjectsAndKeys:
-                                      [NSNumber numberWithFloat:rawRect.size.width], @"width",
-                                      [NSNumber numberWithFloat:rawRect.size.height], @"height",
-                                      nil];
-			
-			return [NSDictionary dictionaryWithObjectsAndKeys:
-					originDict, @"origin",
-					sizeDict, @"size",
-					nil];
-		}
-		
+        static dispatch_once_t onceToken;
+        dispatch_once(&onceToken, ^{
+            // so far, the only class I've found that can't properly be serialized
+            // Using NSClassFromString to avoid import and pulling all of CoreAnimation
+            skippedClasses = [[NSArray alloc] initWithObjects: NSClassFromString(@"CALayer"), 
+                                NSClassFromString(@"UIWindowLayer"),
+                                NSClassFromString(@"MKMapView"), nil];
+        });
+        
+        // eye ball this guy to about 15 classes.
+        self.classMapping = [NSMutableDictionary dictionaryWithCapacity: 15];
+        [self loadClassMapping];
+    }
+    return self;
+}
+
+- (void) dealloc {
+    self.classMapping = nil;
+    [super dealloc];
+}
+
+@synthesize classMapping;
+
+- (void) loadClassMapping {
+    NSLog(@"Loading class mapping definition from ViewAttributeMapping.plist in frank_static_resources.bundle");
+    // find path to the view mapping plist file
+    NSString *staticResourceBundlePath = [[NSBundle mainBundle] pathForResource: @"frank_static_resources.bundle" ofType: nil];
+    NSBundle *staticResourceBundle = [NSBundle bundleWithPath: staticResourceBundlePath];
+    NSString *classMappingPath = [staticResourceBundle pathForResource: @"ViewAttributeMapping" ofType:@"plist"];
+    
+    // abort early if not found
+    if([classMappingPath length] == 0) {
+        NSLog(@"Warning, could NOT find ViewAttributeMapping.plist in frank_static_resources.bundle");
+        return;
+    }
+    
+    // load the plist
+    NSDictionary *theClassMapping = [NSDictionary dictionaryWithContentsOfFile: classMappingPath];
+    // and turn all keys to Class instances and load the attributes for that class
+    for(NSString *key in theClassMapping.keyEnumerator) {
+        Class clazz = NSClassFromString(key);
+        if(clazz == nil) {
+            NSLog(@"Warning, class %@ could not be resolved, skipping.", key);
+            continue;
+        }
+        
+        // abort this class if the value isn't an array
+        id attributes = [theClassMapping objectForKey: key];
+        if(![attributes isKindOfClass: NSArray.class]) {
+            NSLog(@"Warning, attribute value for class %@ isn't an array, skipping.", key);
+            continue;
+        }
+        
+        [classMapping setObject: attributes forKey: clazz];
+    }
+    
+    NSLog(@"Done loading view attribute mapping, found %i classes mapped.\nMapping definition:\n%@", classMapping.count, classMapping);
+}
+
+#pragma mark - Command handling
+- (NSString *)handleCommandWithRequestBody:(NSString *)requestBody {
+    // serialize starting from root window and return json representation of it
+    UIWindow *window = [UIApplication sharedApplication].keyWindow;
+	NSDictionary *dom = [self serializeView: window];
+    return [dom JSONRepresentation];
+}
+
+#pragma mark - view serialization
+- (NSDictionary *) serializeView: (UIView *) view {
+    // eye ball this array to about 20 views, should be more than enough per view.
+    // will avoid resizing the array constantly (and fuck the wasted space).
+    NSMutableDictionary *serializedView = [NSMutableDictionary dictionaryWithCapacity: 20];
+    
+    // start by serializing the view's class string representation
+    Class viewClass = view.class;
+    
+    NSString *className = NSStringFromClass(viewClass);
+    [serializedView setObject: className forKey: @"class"];
+    
+    // iterate on all mapping definition classes looking for a (super) class of the current object
+    for(Class candidate in classMapping.keyEnumerator) {
+        // no match. Next!
+        if(![viewClass isSubclassOfClass: candidate]) {
+            continue;
+        }
+        
+        // now, serialize all defined attributes on the view, if possible
+        NSArray *attributes = [classMapping objectForKey: candidate];
+        for(NSString *attribute in attributes) {
+            // fetch the value for that attribute and add it to the dictionary.
+            // note: valueForAttribute is NOT nil safe (i.e. returns nil if value couldn't be extracted
+            id value = [self valueForAttribute: attribute onObject: view];
+            
+            // just skip nil values, we don't want to pollute the JSON tree with bullshitty empty values
+            if(value == nil) {
+                continue;
+            }
+            
+            // make sure we're not trying to return a field that should be skipped
+            BOOL shouldContinue = NO;
+            // we HAVE to go through all classes, -contains: value.class won't work since we could
+            // get a subclass and equality will just return NO when we want to skip the value.
+            for(Class clazz in skippedClasses) {
+                if([value isKindOfClass: clazz]) {
+                    shouldContinue = YES;
+                    break;
+                }
+            }
+            if (shouldContinue) {
+                continue;
+            }
+            
+            [serializedView setObject: value forKey: attribute];
+        }
+    }
+    
+    // now, recurse on all subviews
+    NSMutableArray *serializedSubviews = [NSMutableArray arrayWithCapacity: view.subviews.count];
+    [serializedView setObject: serializedSubviews forKey: @"subviews"];
+    
+    for(UIView *subview in view.subviews) {
+        NSDictionary *serializedSubview = [self serializeView: subview];
+        [serializedSubviews addObject: serializedSubview];
+    }
+    
+    return serializedView;
+}
+
+#pragma mark - Extracting an attribute
+- (id) valueForAttribute: (NSString *) attribute onObject: (NSObject *) object {
+    // just make sure the input is sane and we're not taking the app down
+    SEL selector = NSSelectorFromString(attribute);
+    if(![object respondsToSelector: selector]) {
+        NSLog(@"DumpCommand.m: Warning \"%@\" does not respond to \"%@\".", object.class, attribute);
+        // TODO maybe we could remove that attribute from the classMapping since it doens't respond to selector?
+        // if we decide to do, this check will have to move to -serializeView: since we've lost knowledge of the 
+        // class mapping defining this attribute
+        return  nil;
+    }
+    
+    // use KVC to get value for attribute
+    id value = [object valueForKey: attribute];
+    
+    // apply special treatment for special cases: UIColor, UIFont, NSValue, add more as appropriate
+    if( [value isKindOfClass: UIColor.class]) { 
+        value = [DumpCommand extractInstanceFromColor: (UIColor *) value];
+    }
+    
+    if([value isKindOfClass: UIFont.class]) {
+        value = [DumpCommand extractInstanceFromFont: (UIFont *) value];
+    }
+    
+    if([value isKindOfClass: NSValue.class]) {
+        value = [DumpCommand extractInstanceFromValue: (NSValue *) value];
+    }
+    
+    return value;
+}
+
+#pragma mark - Special conversions
+#pragma mark UIColor
++ (id) extractInstanceFromColor: (UIColor *) color {
+    CGColorSpaceModel colorModel = CGColorSpaceGetModel(CGColorGetColorSpace(color.CGColor));
+    const CGFloat *colors = CGColorGetComponents(color.CGColor);
+    
+    id value = nil;
+    // so far, only RGB and monochrome color spaces are supported. Adding CMYK and other fancy pants
+    // color spaces should be dead simple, just no need for it so far.
+    switch (colorModel) {
+        case kCGColorSpaceModelRGB:
+            value = [NSDictionary dictionaryWithObjectsAndKeys: 
+                     [NSNumber numberWithFloat:colors[0]], @"red",
+                     [NSNumber numberWithFloat:colors[1]], @"blue",
+                     [NSNumber numberWithFloat:colors[2]], @"green",
+                     [NSNumber numberWithFloat:colors[3]], @"alpha", 
+                     nil];
+            break;
+        case kCGColorSpaceModelMonochrome:
+            value = [NSDictionary dictionaryWithObjectsAndKeys: 
+                     [NSNumber numberWithFloat:colors[0]], @"red",
+                     [NSNumber numberWithFloat:colors[0]], @"blue",
+                     [NSNumber numberWithFloat:colors[0]], @"green",
+                     [NSNumber numberWithFloat:colors[1]], @"alpha", 
+                     nil];
+            break;
+        default:
+            value = @"<NON-RGB COLOR>";
+            break;
+    }
+        
+    return value;
+}
+
++ (id) extractInstanceFromFont: (UIFont *) font {
+    if(font == nil) {
+        return nil;
+    }
+    NSMutableDictionary *dictionary = [NSMutableDictionary dictionaryWithCapacity: 4];
+    
+    // grab font name, family and size
+    [dictionary setObject: font.fontName forKey: @"fontName"];
+    [dictionary setObject: font.familyName forKey: @"familyName"];
+    NSNumber *pointSize = [NSNumber numberWithFloat: font.pointSize];
+    [dictionary setObject: pointSize  forKey: @"pointSize"];
+    
+    return dictionary;
+}
+
+#pragma mark NSValue
++ (id) extractInstanceFromValue:(NSValue *)value {    
+    
+    const char * objcType = [value objCType];
+    if(objcType == NULL) {
+        return nil;
+    }
+    
+    // Numbers just passthrough
+    if([value isKindOfClass: NSNumber.class]) {
+        return value;
+    }
+
+    // CG types
+    if(strcmp(@encode(CGRect), objcType) == 0) {
+        CGRect rawRect;
+        [value getValue:&rawRect];
+        NSDictionary *originDict = [NSDictionary dictionaryWithObjectsAndKeys:
+                                    [NSNumber numberWithFloat:rawRect.origin.x], @"x",
+                                    [NSNumber numberWithFloat:rawRect.origin.y], @"y",
+                                    nil];
+        NSDictionary *sizeDict = [NSDictionary dictionaryWithObjectsAndKeys:
+                                  [NSNumber numberWithFloat:rawRect.size.width], @"width",
+                                  [NSNumber numberWithFloat:rawRect.size.height], @"height",
+                                  nil];
+        
+        return [NSDictionary dictionaryWithObjectsAndKeys:
+                originDict, @"origin",
+                sizeDict, @"size",
+                nil];
+    }
+    
+    if(strcmp(@encode(CGSize), objcType) == 0) {
+        CGSize rawSize;
+        [value getValue:&rawSize];
+        return [NSDictionary dictionaryWithObjectsAndKeys:
+                [NSNumber numberWithFloat:rawSize.width], @"width",
+                [NSNumber numberWithFloat:rawSize.height], @"height",
+                nil];
+    }
+    
+    if(strcmp(@encode(CGPoint), objcType) == 0) {
+        CGPoint point;
+        [value getValue:&point];
+        return [NSDictionary dictionaryWithObjectsAndKeys:
+                [NSNumber numberWithFloat: point.x], @"x",
+                [NSNumber numberWithFloat: point.y], @"y",
+                nil];
+    }
+
+    NSString *typeString = [NSString stringWithFormat:@"%s", objcType]; 
+	if([typeString hasPrefix: @"{"]){
+        // Extract Class name from the type, format is {ClassName=Blablabla}
+		NSString *valueType = [[[typeString substringFromIndex:1] componentsSeparatedByString:@"="] objectAtIndex:0];
 		// In the future we could add support for converting any generic type into a dictionary, if it is helpful to do that
 		return [NSString stringWithFormat:@"<%@>", valueType];
 		
 	}
 	
-	// we should really manually convert other types of value object, but we haven't had a need so far.
-	return @"<UNSUPPORTED VALUE TYPE>";
+    // just return nothing, we can't do much more anyway
+	return nil;
 }
 
-NSObject *jsonifyColor(UIColor *color){
-	CGColorSpaceModel colorModel = CGColorSpaceGetModel(CGColorGetColorSpace(color.CGColor));
-	const CGFloat *colors = CGColorGetComponents(color.CGColor);
-    
-	if( kCGColorSpaceModelRGB == colorModel )
-	{
-		return [NSDictionary dictionaryWithObjectsAndKeys: 
-				[NSNumber numberWithFloat:colors[0]], @"red",
-				[NSNumber numberWithFloat:colors[1]], @"blue",
-				[NSNumber numberWithFloat:colors[2]], @"green",
-				[NSNumber numberWithFloat:colors[3]], @"alpha", 
-				nil];
-	}else if (kCGColorSpaceModelMonochrome == colorModel) {
-		return [NSDictionary dictionaryWithObjectsAndKeys: 
-				[NSNumber numberWithFloat:colors[0]], @"red",
-				[NSNumber numberWithFloat:colors[0]], @"blue",
-				[NSNumber numberWithFloat:colors[0]], @"green",
-				[NSNumber numberWithFloat:colors[1]], @"alpha", 
-				nil];
-	}else {
-		return @"<NON-RGB COLOR>";
-	}
-}
-
-@implementation DumpCommand
-
-+ (NSObject *) jsonify:(id) obj {
-	if( nil == obj )
+#pragma mark - generic JSON conversion
++ (NSObject *) jsonify: (id<NSObject>) obj {
+	if(obj == nil || obj == [NSNull null]) {
 		return [NSNull null];
+    }
 	
-	if( [obj isKindOfClass:[NSNull class]] )
+
+	if([obj isKindOfClass: NSString.class] || 
+       [obj isKindOfClass: NSNumber.class]) {
 		return obj;
-	if( [obj isKindOfClass:[NSString class]] || 
-	   [obj isKindOfClass:[NSNumber class]] )
-		return obj;
-	if( [obj isKindOfClass:[NSValue class]] )
-	{
-		return jsonifyValue((NSValue *)obj);
+    }
+
+	if( [obj isKindOfClass: NSValue.class] ) {
+        return  [DumpCommand extractInstanceFromValue: (NSValue *) obj];
 	}
-	if ([obj isKindOfClass:[UIColor class]]){
-		return jsonifyColor((UIColor *)obj);
+    
+	if ([obj isKindOfClass: UIColor.class]) {
+		return [DumpCommand extractInstanceFromColor: (UIColor *) obj];
 	}
 	
-	return [NSString stringWithFormat:@"<%@>", NSStringFromClass([obj class])];
+	return [NSString stringWithFormat:@"<%@>", NSStringFromClass(obj.class)];
 }
 
-- (NSString *)handleCommandWithRequestBody:(NSString *)requestBody {
-	NSDictionary *dom = describeView( [[UIApplication sharedApplication] keyWindow] );
-	return [dom JSONRepresentation];
-}
 
 @end

--- a/src/DumpCommand.m
+++ b/src/DumpCommand.m
@@ -8,6 +8,8 @@
 
 #import "objc/runtime.h"
 
+#import "ViewJSONSerializer.h"
+
 #import "DumpCommand.h"
 
 #import "UIQuery.h"
@@ -15,11 +17,6 @@
 
 @interface DumpCommand()
 @property (nonatomic, readwrite, retain) NSMutableDictionary *classMapping;
-
-// extracting classes, will end up in a proper static class to avoid weird dependencies
-+ (id) extractInstanceFromValue: (NSValue *) value;
-+ (id) extractInstanceFromColor: (UIColor *) color;
-+ (id) extractInstanceFromFont: (UIFont *) font;
 
 - (NSDictionary *) serializeView: (UIView *) view;
 - (id) valueForAttribute: (NSString *) attribute onObject: (NSObject *) object;
@@ -153,15 +150,15 @@
     
     // apply special treatment for special cases: UIColor, UIFont, NSValue, add more as appropriate
     if( [value isKindOfClass: UIColor.class]) { 
-        value = [DumpCommand extractInstanceFromColor: (UIColor *) value];
+        value = [ViewJSONSerializer extractInstanceFromColor: (UIColor *) value];
     }
     
     if([value isKindOfClass: UIFont.class]) {
-        value = [DumpCommand extractInstanceFromFont: (UIFont *) value];
+        value = [ViewJSONSerializer extractInstanceFromFont: (UIFont *) value];
     }
     
     if([value isKindOfClass: NSValue.class]) {
-        value = [DumpCommand extractInstanceFromValue: (NSValue *) value];
+        value = [ViewJSONSerializer extractInstanceFromValue: (NSValue *) value];
     }
     
     // at this point, we want only NSNumbers, NSArray, NSDictionary, NSString or NSNull,
@@ -177,140 +174,6 @@
     return value;
 }
 
-#pragma mark - Special conversions
-#pragma mark UIColor
-+ (id) extractInstanceFromColor: (UIColor *) color {
-    CGColorSpaceModel colorModel = CGColorSpaceGetModel(CGColorGetColorSpace(color.CGColor));
-    const CGFloat *colors = CGColorGetComponents(color.CGColor);
-    
-    id value = nil;
-    // so far, only RGB and monochrome color spaces are supported. Adding CMYK and other fancy pants
-    // color spaces should be dead simple, just no need for it so far.
-    switch (colorModel) {
-        case kCGColorSpaceModelRGB:
-            value = [NSDictionary dictionaryWithObjectsAndKeys: 
-                     [NSNumber numberWithFloat:colors[0]], @"red",
-                     [NSNumber numberWithFloat:colors[1]], @"blue",
-                     [NSNumber numberWithFloat:colors[2]], @"green",
-                     [NSNumber numberWithFloat:colors[3]], @"alpha", 
-                     nil];
-            break;
-        case kCGColorSpaceModelMonochrome:
-            value = [NSDictionary dictionaryWithObjectsAndKeys: 
-                     [NSNumber numberWithFloat:colors[0]], @"red",
-                     [NSNumber numberWithFloat:colors[0]], @"blue",
-                     [NSNumber numberWithFloat:colors[0]], @"green",
-                     [NSNumber numberWithFloat:colors[1]], @"alpha", 
-                     nil];
-            break;
-        default:
-            value = @"<NON-RGB COLOR>";
-            break;
-    }
-        
-    return value;
-}
-
-+ (id) extractInstanceFromFont: (UIFont *) font {
-    if(font == nil) {
-        return nil;
-    }
-    NSMutableDictionary *dictionary = [NSMutableDictionary dictionaryWithCapacity: 4];
-    
-    // grab font name, family and size
-    [dictionary setObject: font.fontName forKey: @"fontName"];
-    [dictionary setObject: font.familyName forKey: @"familyName"];
-    NSNumber *pointSize = [NSNumber numberWithFloat: font.pointSize];
-    [dictionary setObject: pointSize  forKey: @"pointSize"];
-    
-    return dictionary;
-}
-
-#pragma mark NSValue
-+ (id) extractInstanceFromValue:(NSValue *)value {    
-    
-    const char * objcType = [value objCType];
-    if(objcType == NULL) {
-        return nil;
-    }
-    
-    // Numbers just passthrough
-    if([value isKindOfClass: NSNumber.class]) {
-        return value;
-    }
-
-    // CG types
-    if(strcmp(@encode(CGRect), objcType) == 0) {
-        CGRect rawRect;
-        [value getValue:&rawRect];
-        NSDictionary *originDict = [NSDictionary dictionaryWithObjectsAndKeys:
-                                    [NSNumber numberWithFloat:rawRect.origin.x], @"x",
-                                    [NSNumber numberWithFloat:rawRect.origin.y], @"y",
-                                    nil];
-        NSDictionary *sizeDict = [NSDictionary dictionaryWithObjectsAndKeys:
-                                  [NSNumber numberWithFloat:rawRect.size.width], @"width",
-                                  [NSNumber numberWithFloat:rawRect.size.height], @"height",
-                                  nil];
-        
-        return [NSDictionary dictionaryWithObjectsAndKeys:
-                originDict, @"origin",
-                sizeDict, @"size",
-                nil];
-    }
-    
-    if(strcmp(@encode(CGSize), objcType) == 0) {
-        CGSize rawSize;
-        [value getValue:&rawSize];
-        return [NSDictionary dictionaryWithObjectsAndKeys:
-                [NSNumber numberWithFloat:rawSize.width], @"width",
-                [NSNumber numberWithFloat:rawSize.height], @"height",
-                nil];
-    }
-    
-    if(strcmp(@encode(CGPoint), objcType) == 0) {
-        CGPoint point;
-        [value getValue:&point];
-        return [NSDictionary dictionaryWithObjectsAndKeys:
-                [NSNumber numberWithFloat: point.x], @"x",
-                [NSNumber numberWithFloat: point.y], @"y",
-                nil];
-    }
-
-    NSString *typeString = [NSString stringWithFormat:@"%s", objcType]; 
-	if([typeString hasPrefix: @"{"]){
-        // Extract Class name from the type, format is {ClassName=Blablabla}
-		NSString *valueType = [[[typeString substringFromIndex:1] componentsSeparatedByString:@"="] objectAtIndex:0];
-		// In the future we could add support for converting any generic type into a dictionary, if it is helpful to do that
-		return [NSString stringWithFormat:@"<%@>", valueType];
-		
-	}
-	
-    // just return nothing, we can't do much more anyway
-	return nil;
-}
-
-#pragma mark - generic JSON conversion
-+ (NSObject *) jsonify: (id<NSObject>) obj {
-	if(obj == nil || obj == [NSNull null]) {
-		return [NSNull null];
-    }
-	
-
-	if([obj isKindOfClass: NSString.class] || 
-       [obj isKindOfClass: NSNumber.class]) {
-		return obj;
-    }
-
-	if( [obj isKindOfClass: NSValue.class] ) {
-        return  [DumpCommand extractInstanceFromValue: (NSValue *) obj];
-	}
-    
-	if ([obj isKindOfClass: UIColor.class]) {
-		return [DumpCommand extractInstanceFromColor: (UIColor *) obj];
-	}
-	
-	return [NSString stringWithFormat:@"<%@>", NSStringFromClass(obj.class)];
-}
 
 
 @end

--- a/src/FrankCommandRoute.m
+++ b/src/FrankCommandRoute.m
@@ -11,6 +11,8 @@
 
 #import <QuartzCore/QuartzCore.h>
 
+extern BOOL frankLogEnabled;
+
 @implementation FrankCommandRoute
 
 - (id) init
@@ -54,7 +56,9 @@
 
 - (NSObject<HTTPResponse> *) handleRequestForPath: (NSArray *)path withConnection:(RoutingHTTPConnection *)connection{
     
-	NSLog( @"received request with path %@\nPOST DATA:\n%@", path, connection.postDataAsString );
+    if(frankLogEnabled) {
+        NSLog( @"received request with path %@\nPOST DATA:\n%@", path, connection.postDataAsString );
+    }
     
 	if( [@"screenshot" isEqualToString:[path objectAtIndex:0]] )
 	{
@@ -66,7 +70,9 @@
 		return nil;
 	
 	NSString *response = [command handleCommandWithRequestBody:connection.postDataAsString];
-	NSLog( @"returning:\n%@", response );
+    if(frankLogEnabled) {
+        NSLog( @"returning:\n%@", response );
+    }
 	
 	NSData *browseData = [response dataUsingEncoding:NSUTF8StringEncoding];
 	return [[[HTTPDataResponse alloc] initWithData:browseData] autorelease];

--- a/src/FrankLoader.h
+++ b/src/FrankLoader.h
@@ -8,7 +8,6 @@
 
 #import <Foundation/Foundation.h>
 
-
 @interface FrankLoader : NSObject {
     
 }

--- a/src/FrankLoader.m
+++ b/src/FrankLoader.m
@@ -12,6 +12,8 @@
 
 #import <dlfcn.h>
 
+BOOL frankLogEnabled = NO;
+
 @implementation FrankLoader
 
 + (void)applicationDidBecomeActive:(NSNotification *)notification{

--- a/src/MapOperationCommand.m
+++ b/src/MapOperationCommand.m
@@ -8,6 +8,8 @@
 
 #import "MapOperationCommand.h"
 
+#import "ViewJSONSerializer.h"
+
 #import "SelectorEngineRegistry.h"
 #import "JSON.h"
 #import "Operation.h"
@@ -84,7 +86,7 @@
 	for (UIView *view in viewsToMap) {
 		@try {
 			id result = [self performOperation:operation onView:view];
-			[results addObject:[DumpCommand jsonify:result]];
+			[results addObject:[ViewJSONSerializer jsonify:result]];
 		}
 		@catch (NSException * e) {
 			NSLog( @"Exception while performing operation %@\n%@", operation, e );

--- a/src/StaticResourcesRoute.m
+++ b/src/StaticResourcesRoute.m
@@ -8,6 +8,7 @@
 
 #import "StaticResourcesRoute.h"
 
+extern BOOL frankLogEnabled;
 
 @implementation StaticResourcesRoute
 
@@ -31,7 +32,9 @@
 
 - (NSObject<HTTPResponse> *) handleRequestForPath: (NSArray *)path withConnection:(RoutingHTTPConnection *)connection{
 	NSString *fullPathToRequestedResource = [_staticResourceDirectoryPath stringByAppendingPathComponent: [NSString pathWithComponents:path]];
-	NSLog( @"Checking for static file at %@", fullPathToRequestedResource );
+    if(frankLogEnabled) {
+        NSLog( @"Checking for static file at %@", fullPathToRequestedResource );
+    }
 	BOOL isDir = YES;
 	if( [[NSFileManager defaultManager] fileExistsAtPath:fullPathToRequestedResource isDirectory:&isDir] && !isDir )
 		return [[HTTPFileResponse alloc] initWithFilePath:fullPathToRequestedResource];

--- a/src/ViewJSONSerializer.h
+++ b/src/ViewJSONSerializer.h
@@ -1,0 +1,17 @@
+//
+//  ViewJSONSerializer.h
+//  Frank
+//
+//  Created by Olivier Larivain on 2/24/12.
+//  Copyright (c) 2012 kra. All rights reserved.
+//
+
+#import <Foundation/Foundation.h>
+
+@interface ViewJSONSerializer : NSObject
++ (NSObject *) jsonify: (id<NSObject>) obj;
+
++ (id) extractInstanceFromValue: (NSValue *) value;
++ (id) extractInstanceFromColor: (UIColor *) color;
++ (id) extractInstanceFromFont: (UIFont *) font;
+@end

--- a/src/ViewJSONSerializer.m
+++ b/src/ViewJSONSerializer.m
@@ -1,0 +1,146 @@
+//
+//  ViewJSONSerializer.m
+//  Frank
+//
+//  Created by Olivier Larivain on 2/24/12.
+//  Copyright (c) 2012 kra. All rights reserved.
+//
+
+#import "ViewJSONSerializer.h"
+
+@implementation ViewJSONSerializer
+#pragma mark - generic JSON conversion
++ (NSObject *) jsonify: (id<NSObject>) obj {
+	if(obj == nil || obj == [NSNull null]) {
+		return [NSNull null];
+  }
+	
+  
+	if([obj isKindOfClass: NSString.class] || 
+     [obj isKindOfClass: NSNumber.class]) {
+		return obj;
+  }
+  
+	if( [obj isKindOfClass: NSValue.class] ) {
+    return  [ViewJSONSerializer extractInstanceFromValue: (NSValue *) obj];
+	}
+  
+	if ([obj isKindOfClass: UIColor.class]) {
+		return [ViewJSONSerializer extractInstanceFromColor: (UIColor *) obj];
+	}
+	
+	return [NSString stringWithFormat:@"<%@>", NSStringFromClass(obj.class)];
+}
+
+#pragma mark - Special conversions
+#pragma mark UIColor
++ (id) extractInstanceFromColor: (UIColor *) color {
+  CGColorSpaceModel colorModel = CGColorSpaceGetModel(CGColorGetColorSpace(color.CGColor));
+  const CGFloat *colors = CGColorGetComponents(color.CGColor);
+  
+  id value = nil;
+  // so far, only RGB and monochrome color spaces are supported. Adding CMYK and other fancy pants
+  // color spaces should be dead simple, just no need for it so far.
+  switch (colorModel) {
+    case kCGColorSpaceModelRGB:
+      value = [NSDictionary dictionaryWithObjectsAndKeys: 
+               [NSNumber numberWithFloat:colors[0]], @"red",
+               [NSNumber numberWithFloat:colors[1]], @"blue",
+               [NSNumber numberWithFloat:colors[2]], @"green",
+               [NSNumber numberWithFloat:colors[3]], @"alpha", 
+               nil];
+      break;
+    case kCGColorSpaceModelMonochrome:
+      value = [NSDictionary dictionaryWithObjectsAndKeys: 
+               [NSNumber numberWithFloat:colors[0]], @"red",
+               [NSNumber numberWithFloat:colors[0]], @"blue",
+               [NSNumber numberWithFloat:colors[0]], @"green",
+               [NSNumber numberWithFloat:colors[1]], @"alpha", 
+               nil];
+      break;
+    default:
+      value = @"<NON-RGB COLOR>";
+      break;
+  }
+  
+  return value;
+}
+
++ (id) extractInstanceFromFont: (UIFont *) font {
+  if(font == nil) {
+    return nil;
+  }
+  NSMutableDictionary *dictionary = [NSMutableDictionary dictionaryWithCapacity: 4];
+  
+  // grab font name, family and size
+  [dictionary setObject: font.fontName forKey: @"fontName"];
+  [dictionary setObject: font.familyName forKey: @"familyName"];
+  NSNumber *pointSize = [NSNumber numberWithFloat: font.pointSize];
+  [dictionary setObject: pointSize  forKey: @"pointSize"];
+  
+  return dictionary;
+}
+
+#pragma mark NSValue
++ (id) extractInstanceFromValue:(NSValue *)value {    
+  
+  const char * objcType = [value objCType];
+  if(objcType == NULL) {
+    return nil;
+  }
+  
+  // Numbers just passthrough
+  if([value isKindOfClass: NSNumber.class]) {
+    return value;
+  }
+  
+  // CG types
+  if(strcmp(@encode(CGRect), objcType) == 0) {
+    CGRect rawRect;
+    [value getValue:&rawRect];
+    NSDictionary *originDict = [NSDictionary dictionaryWithObjectsAndKeys:
+                                [NSNumber numberWithFloat:rawRect.origin.x], @"x",
+                                [NSNumber numberWithFloat:rawRect.origin.y], @"y",
+                                nil];
+    NSDictionary *sizeDict = [NSDictionary dictionaryWithObjectsAndKeys:
+                              [NSNumber numberWithFloat:rawRect.size.width], @"width",
+                              [NSNumber numberWithFloat:rawRect.size.height], @"height",
+                              nil];
+    
+    return [NSDictionary dictionaryWithObjectsAndKeys:
+            originDict, @"origin",
+            sizeDict, @"size",
+            nil];
+  }
+  
+  if(strcmp(@encode(CGSize), objcType) == 0) {
+    CGSize rawSize;
+    [value getValue:&rawSize];
+    return [NSDictionary dictionaryWithObjectsAndKeys:
+            [NSNumber numberWithFloat:rawSize.width], @"width",
+            [NSNumber numberWithFloat:rawSize.height], @"height",
+            nil];
+  }
+  
+  if(strcmp(@encode(CGPoint), objcType) == 0) {
+    CGPoint point;
+    [value getValue:&point];
+    return [NSDictionary dictionaryWithObjectsAndKeys:
+            [NSNumber numberWithFloat: point.x], @"x",
+            [NSNumber numberWithFloat: point.y], @"y",
+            nil];
+  }
+  
+  NSString *typeString = [NSString stringWithFormat:@"%s", objcType]; 
+	if([typeString hasPrefix: @"{"]){
+    // Extract Class name from the type, format is {ClassName=Blablabla}
+		NSString *valueType = [[[typeString substringFromIndex:1] componentsSeparatedByString:@"="] objectAtIndex:0];
+		// In the future we could add support for converting any generic type into a dictionary, if it is helpful to do that
+		return [NSString stringWithFormat:@"<%@>", valueType];
+		
+	}
+	
+  // just return nothing, we can't do much more anyway
+	return nil;
+}
+@end


### PR DESCRIPTION
Hey Guys,

Here's the pull request with the updated JSON serialization code.

To sum it up in a nutshell:
- View are now serialized on configuration based schemes. I've added a "ViewAttributeMapping.plist" file to the frank_static_resources bundle. This file a simple ClassName->array of attribute names
- DumpCommand now loads this plist file, figures out the actual classes from it and keeps that in an internal NSDictionary
- On dump, the DumpCommand will build @selector from the attributes and perform them on the views.
- The JSON logic for special cases (CGRects etc) is pretty much the same but has been extracted to a static class to avoid unneeded dependency on DumpCommand.

Looks like its working great, much much faster, Symbiote is happy with it.

I haven't integrated NSJSONSerialization when possible because I got bigger fish to fry these days (experimenting things on the gestures side).

/kra
