### PR TITLE
Added step to simulate entering text from keyboard

### DIFF
--- a/gem/lib/frank-cucumber/core_frank_steps.rb
+++ b/gem/lib/frank-cucumber/core_frank_steps.rb
@@ -130,6 +130,20 @@ When /^I fill in text fields as follows:$/ do |table|
   end
 end
 
+# simulate entering text from keyboard
+When /^I enter the text "([^\\"]*)" from keyboard to the textfield "([^\\"]*)"$/ do |text_to_type, text_field_mark| # !> ambiguous first argument; put parentheses or even spaces
+  selector = "view marked:'#{text_field_mark}' first"
+  if element_exists(selector)
+     touch( selector )
+  else
+     raise "Could not find [#{text_field_mark}], it does not exist."
+  end
+  text_field_selector =  "textField placeholder:'#{text_field_mark}'"
+  frankly_map( text_field_selector, 'becomeFirstResponder' )
+  frankly_map( text_field_selector, 'setText:', text_to_type )
+  frankly_map( text_field_selector, 'endEditing:', true )
+end
+
 # -- Rotate -- #
 Given /^the device is in (a )?landscape orientation$/ do |ignored|
   # for some reason the simulator sometimes starts of reporting its orientation as 'flat'. Workaround for this is to rotate the device then wait a bit


### PR DESCRIPTION
According to many discussions in group and issue #34 I've propose to add special step to simulate keyboard work. We need to trigger some events after editing and make textfield active before start enter the text (by touch). Please, check and approve.
