### PR TITLE
Shelly: Added UIView helpers to help detect if a view is animating

### DIFF
--- a/lib/Shelley/Shelley.xcodeproj/project.pbxproj
+++ b/lib/Shelley/Shelley.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		4D77E71915188374000D0EEE /* QuartzCore.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 4D77E71815188374000D0EEE /* QuartzCore.framework */; };
 		D610CA6213D9F8D8008AB1F5 /* SYParentsTests.m in Sources */ = {isa = PBXBuildFile; fileRef = D610CA6113D9F8D8008AB1F5 /* SYParentsTests.m */; };
 		D610CA6513D9F9E7008AB1F5 /* SenTestCase+Extensions.m in Sources */ = {isa = PBXBuildFile; fileRef = D610CA6413D9F9E7008AB1F5 /* SenTestCase+Extensions.m */; };
 		D610CA6813DA0752008AB1F5 /* SYPredicateFilterTests.m in Sources */ = {isa = PBXBuildFile; fileRef = D610CA6713DA0752008AB1F5 /* SYPredicateFilterTests.m */; };
@@ -49,6 +50,7 @@
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
+		4D77E71815188374000D0EEE /* QuartzCore.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = QuartzCore.framework; path = System/Library/Frameworks/QuartzCore.framework; sourceTree = SDKROOT; };
 		D610CA6013D9F8D8008AB1F5 /* SYParentsTests.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = SYParentsTests.h; sourceTree = "<group>"; };
 		D610CA6113D9F8D8008AB1F5 /* SYParentsTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = SYParentsTests.m; sourceTree = "<group>"; };
 		D610CA6313D9F9E7008AB1F5 /* SenTestCase+Extensions.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "SenTestCase+Extensions.h"; sourceTree = "<group>"; };
@@ -108,6 +110,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				4D77E71915188374000D0EEE /* QuartzCore.framework in Frameworks */,
 				D6E8FF3613D3DC9200D24F43 /* Foundation.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -202,6 +205,7 @@
 		D6E8FF3413D3DC9200D24F43 /* Frameworks */ = {
 			isa = PBXGroup;
 			children = (
+				4D77E71815188374000D0EEE /* QuartzCore.framework */,
 				D6E8FF3513D3DC9200D24F43 /* Foundation.framework */,
 				D6CF399413D3E195000C7901 /* UIKit.framework */,
 				D6CF399713D3E195000C7901 /* CoreGraphics.framework */,

--- a/lib/Shelley/Shelley/UIView+ShelleyExtensions.m
+++ b/lib/Shelley/Shelley/UIView+ShelleyExtensions.m
@@ -8,6 +8,8 @@
 
 #import "LoadableCategory.h"
 
+#import <QuartzCore/QuartzCore.h>
+
 MAKE_CATEGORIES_LOADABLE(UIView_ShelleyExtensions)
 
 BOOL substringMatch(NSString *actualString, NSString *expectedSubstring){	
@@ -22,6 +24,14 @@ BOOL substringMatch(NSString *actualString, NSString *expectedSubstring){
 
 - (BOOL) markedExactly:(NSString *)targetLabel{
     return [[self accessibilityLabel] isEqualToString:targetLabel];
+}
+
+- (BOOL) isAnimating {
+    return (self.layer.animationKeys.count > 0);
+}
+
+- (BOOL) isNotAnimating {
+    return (self.layer.animationKeys.count == 0);
 }
 
 @end


### PR DESCRIPTION
I ran into an issue where interacting with UIAlertView's was happening too fast (i.e. before the view finished animating) - in this particular case one UIAlertView would show another, but the still active animation of the previous alert view prevented it from showing.

Putting in a sleep worked but I wanted a faster solution. By adding a `isNotAnimating` selector to UIView I can now filter by this.

My alert view steps (based on the code in [this pull request](https://github.com/moredip/Frank/pull/64) which hasn't been merged in) now look like this:

``` ruby
WAIT_TIMEOUT = ENV['WAIT_TIMEOUT'].to_i || 240

Given /^I (do not )?see an alert view titled "([^\"]*)"$/ do |qualifier, expected_mark|
  expected_to_see = "do not " != qualifier

  values = []
  Timeout::timeout(WAIT_TIMEOUT) do
    until !(values = frankly_map( 'alertView isNotAnimating', 'title')).empty?
      sleep 0.1
    end
  end

  if expected_to_see
    values.should include(expected_mark)
  else
    values.should_not include(expected_mark)
  end
end

Given /^I (do not )?see an alert view with the message "([^\"]*)"$/ do |qualifier, expected_mark|
  expected_to_see = "not " != qualifier

  values = []
  Timeout::timeout(WAIT_TIMEOUT) do
    until !(values = frankly_map( 'alertView isNotAnimating', 'message')).empty?
      sleep 0.1
    end
  end

  if expected_to_see
    values.should include(expected_mark)
  else
    values.should_not include(expected_mark)
  end
end
```

This change solves my problem - the code find the alert view the moment it stops animating. I suspect this pattern of waiting for a view to stop animating will be something I return to more than once as this first project using Frank grows.
