### PR TITLE
Add conversion to accept BOOL parameters

### DIFF
--- a/src/Operation.m
+++ b/src/Operation.m
@@ -41,7 +41,9 @@
 	}else if( !strcmp(objCType, @encode(uint)) ){
 		*((uint *)buffer) = [number unsignedIntValue];
 	}else if( !strcmp(objCType, @encode(double)) ){
-		*((double *)buffer) = [number doubleValue];        
+		*((double *)buffer) = [number doubleValue];
+	} else if ( !strcmp(objCType, @encode(char)) ) {
+		*((char*)buffer) = [number charValue];
 	}else {
 		NSLog(@"Didn't know how to convert NSNumber to type %s", objCType); 
 	}	


### PR DESCRIPTION
BOOL parameters are not correctly de-serialized. Method which takes BOOL parameters, including `UISwitch#setOn:`, does not work.

This commit adds conversion from `NSNumber` to `BOOL` and `char`.
