### PR TITLE
Adding the capability to switch the application use URL scheme

### DIFF
--- a/src/FrankServer.m
+++ b/src/FrankServer.m
@@ -17,15 +17,10 @@
 #import "OrientationCommand.h"
 #import "AppCommand.h"
 #import "AccessibilityCheckCommand.h"
-#import "KeyboardCommand.h"
+#import "SwitchAppCommand.h"
 
-static NSUInteger __defaultPort = FRANK_SERVER_PORT;
 @implementation FrankServer
 
-+ (void)setDefaultHttpPort:(NSUInteger)port
-{
-    __defaultPort = port;
-}
 - (id) initWithDefaultBundle {
 	return [self initWithStaticFrankBundleNamed: @"frank_static_resources"];
 }
@@ -43,8 +38,8 @@ static NSUInteger __defaultPort = FRANK_SERVER_PORT;
 		[frankCommandRoute registerCommand:[[[MapOperationCommand alloc]init]autorelease] withName:@"map"];
 		[frankCommandRoute registerCommand:[[[OrientationCommand alloc]init]autorelease] withName:@"orientation"];
 		[frankCommandRoute registerCommand:[[[AccessibilityCheckCommand alloc] init]autorelease] withName:@"accessibility_check"];
+        [frankCommandRoute registerCommand:[[[SwitchAppCommand alloc]init]autorelease] withName:@"switchToAutomationAgent"];
 		[frankCommandRoute registerCommand:[[[AppCommand alloc] init]autorelease] withName:@"app_exec"];
-        [frankCommandRoute registerCommand:[[[KeyboardCommand alloc] init]autorelease] withName:@"type_into_keyboard"];
 		[[RequestRouter singleton] registerRoute:frankCommandRoute];
 		
 		StaticResourcesRoute *staticRoute = [[[StaticResourcesRoute alloc] initWithStaticResourceSubDir:bundleName] autorelease];
@@ -55,7 +50,7 @@ static NSUInteger __defaultPort = FRANK_SERVER_PORT;
 		[_httpServer setName:@"Frank UISpec server"];
 		[_httpServer setType:@"_http._tcp."];
 		[_httpServer setConnectionClass:[RoutingHTTPConnection class]];
-		[_httpServer setPort:__defaultPort];
+		[_httpServer setPort:FRANK_SERVER_PORT];
 		NSLog( @"Creating the server: %@", _httpServer );
 	}
 	return self;

--- a/src/FrankServer.m
+++ b/src/FrankServer.m
@@ -18,6 +18,7 @@
 #import "AppCommand.h"
 #import "AccessibilityCheckCommand.h"
 #import "KeyboardCommand.h"
+#import "SwitchAppCommand.h"
 
 static NSUInteger __defaultPort = FRANK_SERVER_PORT;
 @implementation FrankServer

--- a/src/FrankServer.m
+++ b/src/FrankServer.m
@@ -17,10 +17,15 @@
 #import "OrientationCommand.h"
 #import "AppCommand.h"
 #import "AccessibilityCheckCommand.h"
-#import "SwitchAppCommand.h"
+#import "KeyboardCommand.h"
 
+static NSUInteger __defaultPort = FRANK_SERVER_PORT;
 @implementation FrankServer
 
++ (void)setDefaultHttpPort:(NSUInteger)port
+{
+    __defaultPort = port;
+}
 - (id) initWithDefaultBundle {
 	return [self initWithStaticFrankBundleNamed: @"frank_static_resources"];
 }
@@ -38,8 +43,9 @@
 		[frankCommandRoute registerCommand:[[[MapOperationCommand alloc]init]autorelease] withName:@"map"];
 		[frankCommandRoute registerCommand:[[[OrientationCommand alloc]init]autorelease] withName:@"orientation"];
 		[frankCommandRoute registerCommand:[[[AccessibilityCheckCommand alloc] init]autorelease] withName:@"accessibility_check"];
-        [frankCommandRoute registerCommand:[[[SwitchAppCommand alloc]init]autorelease] withName:@"switchToAutomationAgent"];
 		[frankCommandRoute registerCommand:[[[AppCommand alloc] init]autorelease] withName:@"app_exec"];
+		[frankCommandRoute registerCommand:[[[SwitchAppCommand alloc]init]autorelease] withName:@"switchToAutomationAgent"];
+        	[frankCommandRoute registerCommand:[[[KeyboardCommand alloc] init]autorelease] withName:@"type_into_keyboard"];
 		[[RequestRouter singleton] registerRoute:frankCommandRoute];
 		
 		StaticResourcesRoute *staticRoute = [[[StaticResourcesRoute alloc] initWithStaticResourceSubDir:bundleName] autorelease];
@@ -50,7 +56,7 @@
 		[_httpServer setName:@"Frank UISpec server"];
 		[_httpServer setType:@"_http._tcp."];
 		[_httpServer setConnectionClass:[RoutingHTTPConnection class]];
-		[_httpServer setPort:FRANK_SERVER_PORT];
+		[_httpServer setPort:__defaultPort];
 		NSLog( @"Creating the server: %@", _httpServer );
 	}
 	return self;

--- a/src/SwitchAppCommand.h
+++ b/src/SwitchAppCommand.h
@@ -1,0 +1,17 @@
+//
+//  SwitchAppCommand.h
+//  Frank
+//
+//  Created by Pattapong
+//  Copyright (c) 2012 __MyCompanyName__. All rights reserved.
+//
+#import <Foundation/Foundation.h>
+
+#import "FrankCommandRoute.h"
+
+
+@interface SwitchAppCommand : NSObject<FrankCommand> {
+     
+}
+
+@end

--- a/src/SwitchAppCommand.m
+++ b/src/SwitchAppCommand.m
@@ -1,0 +1,26 @@
+//
+//  SwitchAppCommand.m
+//  Frank
+//
+//  Created by Pattapong
+//  Copyright (c) 2012 __MyCompanyName__. All rights reserved.
+//
+
+#import "SwitchAppCommand.h"
+
+@implementation SwitchAppCommand
+
+- (NSString *)handleCommandWithRequestBody:(NSString *)requestBody {
+    UIApplication *agentApplication = [UIApplication sharedApplication];
+    NSURL *url = [NSURL URLWithString:@"automationagent://"];
+    if ([agentApplication canOpenURL:url]) {
+        [agentApplication openURL:url];
+        return @"{\"outcome\":\"SUCCESS\"}";
+    }
+    else {
+        NSLog(@"The Receiver App is not installed. It must be installed to send text.");
+        return @"{\"outcome\":\"FAILED\"}";
+    }
+}
+
+@end


### PR DESCRIPTION
Hi Pete,
Could you please adding these to the master?

The propose of this is to be able to run the continuous UI testing by having the appLauncher as a foreground while the new AUT is being installed. So User can execute
http://<iPad adress>:37265/SwitchToAutomationAgent
To Frank server, to switch to appLauncher which implement the URL scheme.

Thank you,

Pat
