### PR TITLE
base_url should be a URI not a string

### DIFF
--- a/gem/lib/frank-cucumber/gateway.rb
+++ b/gem/lib/frank-cucumber/gateway.rb
@@ -7,7 +7,7 @@ class Gateway
   DEFAULT_BASE_URL = "http://localhost:37265/"
 
   def initialize( base_url = nil )
-    @base_url = URI.parse (base_url || DEFAULT_BASE_URL).to_s
+    @base_url = URI.parse (base_url || DEFAULT_BASE_URL)
   end
 
   def ping


### PR DESCRIPTION
I get this error when I try to run my cucumber tests:

undefined method `path=' for "http://localhost:37265/":String (NoMethodError)
