### PR TITLE
Stringify method_name in frankly_map and app_exec

### DIFF
--- a/gem/lib/frank-cucumber/frank_helper.rb
+++ b/gem/lib/frank-cucumber/frank_helper.rb
@@ -114,7 +114,7 @@ module FrankHelper
   end
 
   def app_exec(method_name, *method_args)
-    operation_map = Gateway.build_operation_map(method_name,method_args)
+    operation_map = Gateway.build_operation_map(method_name.to_s, method_args)
     
     res = frank_server.send_post( 
       'app_exec', 
@@ -125,7 +125,7 @@ module FrankHelper
   end
 
   def frankly_map( query, method_name, *method_args )
-    operation_map = Gateway.build_operation_map(method_name,method_args)
+    operation_map = Gateway.build_operation_map(method_name.to_s, method_args)
 
     res = frank_server.send_post( 
       'map',


### PR DESCRIPTION
Since we are using symbols for method_names in some of frankly_map calls, the latest version of Frank throw errors. I know this might be a dirty hack, but we are wondering if our code could be continue working.
