### PR TITLE
Easy install xcconfig fixes

### DIFF
--- a/gem/frank-skeleton/frankify.xcconfig
+++ b/gem/frank-skeleton/frankify.xcconfig
@@ -1,4 +1,4 @@
 INSTALL_PATH = /./
 
-FRANK_LDFLAGS = -framework CFNetwork -lShelley -lFrank
+FRANK_LDFLAGS = -all_load -ObjC -framework CFNetwork -lShelley -lFrank
 GCC_PREPROCESSOR_DEFINITIONS_NOT_USED_IN_PRECOMPS = FRANKIFIED

--- a/gem/frank-skeleton/frankify.xcconfig
+++ b/gem/frank-skeleton/frankify.xcconfig
@@ -1,4 +1,4 @@
 INSTALL_PATH = /./
 
-OTHER_LDFLAGS = $(inherited) -all_load -ObjC -framework CFNetwork -lShelley -lFrank -L Frank
+OTHER_LDFLAGS = $(inherited) -all_load -ObjC -framework CFNetwork -lShelley -lFrank
 GCC_PREPROCESSOR_DEFINITIONS_NOT_USED_IN_PRECOMPS = FRANKIFIED

--- a/gem/frank-skeleton/frankify.xcconfig
+++ b/gem/frank-skeleton/frankify.xcconfig
@@ -1,4 +1,4 @@
 INSTALL_PATH = /./
 
-OTHER_LDFLAGS = $(inherited) -all_load -ObjC -framework CFNetwork -lShelley -lFrank
+FRANK_LDFLAGS = -framework CFNetwork -lShelley -lFrank
 GCC_PREPROCESSOR_DEFINITIONS_NOT_USED_IN_PRECOMPS = FRANKIFIED

--- a/gem/lib/frank-cucumber/cli.rb
+++ b/gem/lib/frank-cucumber/cli.rb
@@ -129,7 +129,7 @@ module Frank
     end
 
     def build_output_dir
-      "Frank/frankified_build"
+      File.expand_path "Frank/frankified_build"
     end
 
     def frankified_app_dir

--- a/gem/lib/frank-cucumber/cli.rb
+++ b/gem/lib/frank-cucumber/cli.rb
@@ -55,7 +55,7 @@ module Frank
 
       extra_opts = XCODEBUILD_OPTIONS.map{ |o| "-#{o} #{options[o]}" if options[o] }.compact.join(' ')
 
-      run "xcodebuild -xcconfig Frank/frankify.xcconfig install #{extra_opts} -configuration Debug -sdk iphonesimulator DSTROOT=#{build_output_dir} APP_NAME=#{product_name} FRANK_LIBRARY_SEARCH_PATHS=#{frank_lib_directory}"
+      run "xcodebuild -xcconfig Frank/frankify.xcconfig build install #{extra_opts} -configuration Debug -sdk iphonesimulator DSTROOT=#{build_output_dir} APP_NAME=#{product_name} FRANK_LIBRARY_SEARCH_PATHS=#{frank_lib_directory}"
 
       in_root do
         FileUtils.cp_r( 

--- a/gem/lib/frank-cucumber/cli.rb
+++ b/gem/lib/frank-cucumber/cli.rb
@@ -55,7 +55,7 @@ module Frank
 
       extra_opts = XCODEBUILD_OPTIONS.map{ |o| "-#{o} #{options[o]}" if options[o] }.compact.join(' ')
 
-      run "xcodebuild -xcconfig Frank/frankify.xcconfig install #{extra_opts} -configuration Debug -sdk iphonesimulator DSTROOT=#{build_output_dir} PRODUCT_NAME=#{product_name} FRANK_LIBRARY_SEARCH_PATHS=#{frank_lib_directory}"
+      run "xcodebuild -xcconfig Frank/frankify.xcconfig install #{extra_opts} -configuration Debug -sdk iphonesimulator DSTROOT=#{build_output_dir} APP_NAME=#{product_name} FRANK_LIBRARY_SEARCH_PATHS=#{frank_lib_directory}"
 
       in_root do
         FileUtils.cp_r( 

--- a/gem/lib/frank-cucumber/cli.rb
+++ b/gem/lib/frank-cucumber/cli.rb
@@ -55,7 +55,7 @@ module Frank
 
       extra_opts = XCODEBUILD_OPTIONS.map{ |o| "-#{o} #{options[o]}" if options[o] }.compact.join(' ')
 
-      run "xcodebuild -xcconfig Frank/frankify.xcconfig install #{extra_opts} -configuration Debug -sdk iphonesimulator DSTROOT=#{build_output_dir} PRODUCT_NAME=#{product_name}"
+      run "xcodebuild -xcconfig Frank/frankify.xcconfig install #{extra_opts} -configuration Debug -sdk iphonesimulator DSTROOT=#{build_output_dir} PRODUCT_NAME=#{product_name} FRANK_LIBRARY_SEARCH_PATHS=#{frank_lib_directory}"
 
       in_root do
         FileUtils.cp_r( 
@@ -126,6 +126,10 @@ module Frank
 
     def app_bundle_name
       "#{product_name}.app"
+    end
+    
+    def frank_lib_directory
+      File.expand_path "Frank"
     end
 
     def build_output_dir

--- a/gem/lib/frank-cucumber/version.rb
+++ b/gem/lib/frank-cucumber/version.rb
@@ -1,5 +1,5 @@
 module Frank
   module Cucumber
-    VERSION = "0.9.5.pre1"
+    VERSION = "0.9.5.pre2"
   end
 end


### PR DESCRIPTION
Also posted to Frank mailing list. I changed the variable names so they didn't break dependent projects. Here are my notes on what I changed in Frank, and how you might need to set up your project to use these new settings.

While it seems like a lot of steps, it's only a few build settings, and means you don't need to duplicate the target to use Frank, which is great. We should also automate fiddling with these build settings, but that's a separate piece of work.

The changes I needed to make to Frank:
- build_output_dir needed to be absolute, because my workspaces have projects in nested directories, and some things were relative to the workspace and others were relative to the project. Absolute path fixed that.
- the library search path also needed to be absolute (to find libFrank.a and libShelley.a), so I fed that through in a separate variable, rather than "-L Frank", called FRANK_LIBRARY_SEARCH_PATHS
- use a different variable name for the linker flags (FRANK_LDFLAGS). Since most projects I work on also have -all_load and -ObjC added, these are duplicated in the final compile but seem pretty harmless
- when running xcodebuild, I changed it to run both the 'build' and 'install' action. When running install, the headers and libs for dependent projects go into strange places and the header search paths don't find them. This answer (http://stackoverflow.com/a/5607353/223558) suggests hardcoding some header paths, I prefer to just also run the 'build' action, where headers go to the right place

The changes I needed to make to my project:
- made sure SKIP_INSTALL was set to NO... this isn't related to my changes, but for some reason I had it to YES which results in the 'install' action not copying files to the right place, as Luke Redpath found out last night https://twitter.com/lukeredpath/statuses/223402779262189570
- joined in the Frank linker and search path flags into the build settings for my main target:

OTHER_LDFLAGS = $(inherited) $(FRANK_LDFLAGS)
LIBRARY_SEARCH_PATHS = $(inherited) $(FRANK_LIBRARY_SEARCH_PATHS)
- linked up the APP_NAME parameter to default to the TARGET_NAME when running from Xcode (as it did before implicitly anyway), but to allow it to be overridden for the Frankified build and not clash with any dependent apps:

APP_NAME = $(TARGET_NAME) // this gets clobbered by the Frank xcconfig when running from frank build
PRODUCT_NAME = $(APP_NAME)
- Something just for me, probably: I also used the PRODUCT_NAME to link to Info.plist and .pch dynamically (because I have some general xcconfigs I use for multiple projects). You probably don't have this problem, but if you do, obviously these filenames don't change to Frankified-Info.plist... the solution is to use TARGET_NAME directly rather than PRODUCT_NAME, since this doesn't change
- Another one just for me: my unit tests compile during the same build, and it needs the BUNDLE_LOADER and TEST_HOST to link to the app being compile, it also needs to be linked to APP_NAME. I expect most people have a separate test scheme, so wont have this problem

APP_NAME = MyAppNameInXcode // gets clobbered by frank xcconfig
BUNDLE_LOADER = $(BUILT_PRODUCTS_DIR)/$(APP_NAME).app/$(APP_NAME)
TEST_HOST = $(BUNDLE_LOADER)
