### PR TITLE
Add ability to override Build Configuration in frank setup

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -48,9 +48,3 @@ desc "copies contents of dist dir to the frank-cucumber gem's frank-skeleton"
 task :copy_dist_to_gem do
   sh "cp -r dist/* gem/frank-skeleton/"
 end
-
-desc "create a gem and copy it to the target_dir"
-task :gem_it_up, :target_dir do |t, args|
-  sh "cd gem && gem build frank-cucumber.gemspec && cp frank-cucumber-0.9.5.pre7.gem #{args[:target_dir]}"
-end
-

--- a/Rakefile
+++ b/Rakefile
@@ -49,3 +49,8 @@ task :copy_dist_to_gem do
   sh "cp -r dist/* gem/frank-skeleton/"
 end
 
+desc "create a gem and copy it to the target_dir"
+task :gem_it_up, :target_dir do |t, args|
+  sh "cd gem && gem build frank-cucumber.gemspec && cp frank-cucumber-0.9.5.pre7.gem #{args[:target_dir]}"
+end
+

--- a/gem/lib/frank-cucumber/cli.rb
+++ b/gem/lib/frank-cucumber/cli.rb
@@ -25,12 +25,12 @@ module Frank
     WITHOUT_SERVER = "without-cocoa-http-server"
     desc "setup", "set up your iOS app by adding a Frank subdirectory containing everything Frank needs"
     method_option WITHOUT_SERVER, :type => :boolean
+    method_option :build_configuration, :aliases=>'--conf', :type=>:string, :default => 'Debug'
     def setup
       @without_http_server = options[WITHOUT_SERVER]
-
       directory ".", "Frank"
 
-      Frankifier.frankify!( File.expand_path('.') )
+      Frankifier.frankify!( File.expand_path('.'), :build_config => options[:build_configuration] )
     end
 
     desc "update", "updates the frank server components inside your Frank directory"

--- a/gem/lib/frank-cucumber/frankifier.rb
+++ b/gem/lib/frank-cucumber/frankifier.rb
@@ -12,7 +12,7 @@ class Frankifier
 
   def initialize( root_dir, options = {} )
     @root = Pathname.new( root_dir )
-    @build_config = options[:build_config]
+    @target_build_configuration = options[:build_config]
   end
 
   def frankify!
@@ -75,7 +75,7 @@ class Frankifier
   end
 
   def add_frank_entry_to_build_setting( build_setting, entry_to_add )
-    setting_array = Array( debug_build_settings[build_setting] )
+    setting_array = Array( build_settings_to_edit[build_setting] )
 
     if setting_array.find{ |flag| flag.start_with? "$(FRANK_" }
       say "It appears that your Debug configuration's #{build_setting} build setting already include some FRANK setup. Namely: #{setting_array.inspect}. I won't change anything here."
@@ -88,11 +88,11 @@ class Frankifier
     setting_array.uniq! # mainly to avoid duplicate $(inherited) entries
     say "... #{build_setting} is now: #{setting_array.inspect}"
 
-    debug_build_settings[build_setting] = setting_array
+    build_settings_to_edit[build_setting] = setting_array
   end
 
-  def debug_build_settings
-    @_debug_build_settings ||= @target.build_configuration_list.build_settings(@build_config)
+  def build_settings_to_edit
+    @_build_settings_to_edit ||= @target.build_configuration_list.build_settings(@target_build_configuration)
   end
 
   def save_changes

--- a/gem/lib/frank-cucumber/frankifier.rb
+++ b/gem/lib/frank-cucumber/frankifier.rb
@@ -4,14 +4,15 @@ require 'xcodeproj'
 class Frankifier
   include Thor::Shell
 
-  def self.frankify! root_dir
-    me = new(root_dir)
+  def self.frankify! root_dir, options = {}
+    me = new(root_dir, options)
     me.frankify!
     me
   end
 
-  def initialize( root_dir )
+  def initialize( root_dir, options = {} )
     @root = Pathname.new( root_dir )
+    @build_config = options[:build_config]
   end
 
   def frankify!
@@ -91,7 +92,7 @@ class Frankifier
   end
 
   def debug_build_settings
-    @_debug_build_settings ||= @target.build_configuration_list.build_settings('Debug')
+    @_debug_build_settings ||= @target.build_configuration_list.build_settings(@build_config)
   end
 
   def save_changes


### PR DESCRIPTION
We use custom build configurations in order to build the application targeting different environments.  This change makes it so you can pass an option (defaulted to "Debug") build configuration into frank setup with the --conf or --build_configuration  options.

usage:

frank setup --conf="AL Debug QA"
frank setup --build_configuration="AL Debug QA"

I also added a new Rake task :gem_it_up[target_dir] for building the gem and copying it to a specified directory (to change/deploy/test cycle).
