### PR TITLE
Add an 'exit' command to the server

### DIFF
--- a/Frank.xcodeproj/project.pbxproj
+++ b/Frank.xcodeproj/project.pbxproj
@@ -7,6 +7,8 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		07AE056614C93D380023B8D0 /* ExitCommand.h in Headers */ = {isa = PBXBuildFile; fileRef = 07AE056414C93D380023B8D0 /* ExitCommand.h */; };
+		07AE056714C93D380023B8D0 /* ExitCommand.m in Sources */ = {isa = PBXBuildFile; fileRef = 07AE056514C93D380023B8D0 /* ExitCommand.m */; };
 		4C1DD76C12BADFE100E10B8C /* OrientationCommand.m in Sources */ = {isa = PBXBuildFile; fileRef = 4C1DD76812BADFE100E10B8C /* OrientationCommand.m */; };
 		4C1DD76D12BADFE100E10B8C /* OrientationCommand.h in Headers */ = {isa = PBXBuildFile; fileRef = 4C1DD76912BADFE100E10B8C /* OrientationCommand.h */; };
 		4C1DD76E12BADFE100E10B8C /* AppCommand.m in Sources */ = {isa = PBXBuildFile; fileRef = 4C1DD76A12BADFE100E10B8C /* AppCommand.m */; };
@@ -152,6 +154,8 @@
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
+		07AE056414C93D380023B8D0 /* ExitCommand.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = ExitCommand.h; path = src/ExitCommand.h; sourceTree = "<group>"; };
+		07AE056514C93D380023B8D0 /* ExitCommand.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = ExitCommand.m; path = src/ExitCommand.m; sourceTree = "<group>"; };
 		4C1DD76812BADFE100E10B8C /* OrientationCommand.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = OrientationCommand.m; path = src/OrientationCommand.m; sourceTree = "<group>"; };
 		4C1DD76912BADFE100E10B8C /* OrientationCommand.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = OrientationCommand.h; path = src/OrientationCommand.h; sourceTree = "<group>"; };
 		4C1DD76A12BADFE100E10B8C /* AppCommand.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = AppCommand.m; path = src/AppCommand.m; sourceTree = "<group>"; };
@@ -380,6 +384,8 @@
 				D6BD521D146C34BF001770B1 /* SelectorEngineRegistry.m */,
 				D6BD5220146C36A3001770B1 /* UIQuerySelectorEngine.h */,
 				D6BD5221146C36A3001770B1 /* UIQuerySelectorEngine.m */,
+				07AE056414C93D380023B8D0 /* ExitCommand.h */,
+				07AE056514C93D380023B8D0 /* ExitCommand.m */,
 			);
 			name = src;
 			sourceTree = "<group>";
@@ -649,6 +655,7 @@
 				D6325EE21437F7180057330D /* UIProxy.h in Headers */,
 				D6325EE41437F7180057330D /* WaitUntilIdle.h in Headers */,
 				D6BD5222146C36A3001770B1 /* UIQuerySelectorEngine.h in Headers */,
+				07AE056614C93D380023B8D0 /* ExitCommand.h in Headers */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -786,6 +793,7 @@
 				D6B1056114644827000DD32F /* UIQuery+ShelleyCompatibiilityOverrides.m in Sources */,
 				D6BD521F146C34BF001770B1 /* SelectorEngineRegistry.m in Sources */,
 				D6BD5223146C36A3001770B1 /* UIQuerySelectorEngine.m in Sources */,
+				07AE056714C93D380023B8D0 /* ExitCommand.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/src/ExitCommand.h
+++ b/src/ExitCommand.h
@@ -1,0 +1,16 @@
+//
+//  ExitCommand.h
+//  Frank
+//
+//  Created by Martin Hauner on 26.09.10.
+//  Copyright 2010 Martin Hauner. All rights reserved.
+//
+
+#import <Foundation/Foundation.h>
+#import "FrankCommandRoute.h"
+
+@interface ExitCommand : NSObject<FrankCommand> {
+  
+}
+
+@end

--- a/src/ExitCommand.m
+++ b/src/ExitCommand.m
@@ -1,0 +1,18 @@
+//
+//  ExitCommand.m
+//  Frank
+//
+//  Created by Martin Hauner on 26.09.10.
+//  Copyright 2010 Martin Hauner. All rights reserved.
+//
+
+#import "ExitCommand.h"
+
+
+@implementation ExitCommand
+
+- (NSString *)handleCommandWithRequestBody:(NSString *)requestBody {
+  exit (0);
+}
+
+@end

--- a/src/FrankServer.m
+++ b/src/FrankServer.m
@@ -15,6 +15,7 @@
 #import "DumpCommand.h"
 #import "MapOperationCommand.h"
 #import "OrientationCommand.h"
+#import "ExitCommand.h"
 #import "AppCommand.h"
 #import "AccessibilityCheckCommand.h"
 
@@ -38,6 +39,7 @@
 		[frankCommandRoute registerCommand:[[[OrientationCommand alloc]init]autorelease] withName:@"orientation"];
 		[frankCommandRoute registerCommand:[[[AccessibilityCheckCommand alloc] init]autorelease] withName:@"accessibility_check"];
 		[frankCommandRoute registerCommand:[[[AppCommand alloc] init]autorelease] withName:@"app_exec"];
+    [frankCommandRoute registerCommand:[[[ExitCommand alloc] init] autorelease] withName:@"exit"];
 		[[RequestRouter singleton] registerRoute:frankCommandRoute];
 		
 		StaticResourcesRoute *staticRoute = [[[StaticResourcesRoute alloc] initWithStaticResourceSubDir:bundleName] autorelease];

--- a/src/FrankServer.m
+++ b/src/FrankServer.m
@@ -47,7 +47,7 @@ static NSUInteger __defaultPort = FRANK_SERVER_PORT;
 		[frankCommandRoute registerCommand:[[[AppCommand alloc] init]autorelease] withName:@"app_exec"];
         [frankCommandRoute registerCommand:[[[KeyboardCommand alloc] init]autorelease] withName:@"type_into_keyboard"];
         [frankCommandRoute registerCommand:[[[EnginesCommand alloc] init]autorelease] withName:@"engines"];
-    [frankCommandRoute registerCommand:[[[ExitCommand alloc] init] autorelease] withName:@"exit"];
+        [frankCommandRoute registerCommand:[[[ExitCommand alloc] init] autorelease] withName:@"exit"];
 		[[RequestRouter singleton] registerRoute:frankCommandRoute];
 		
 		StaticResourcesRoute *staticRoute = [[[StaticResourcesRoute alloc] initWithStaticResourceSubDir:bundleName] autorelease];


### PR DESCRIPTION
A simple command to exit the app. Useful for putting in tests run by a CI server. I just want to see this in moredip/master and use it with the other improvements that have been made to the project -- credits to @hauner and @rickerbh for the implementations, ideas, and explicative blog posts discoverable by google ;)

http://softnoise.wordpress.com/2010/11/14/ios-running-cucumberfrank-with-code-coverage-in-hudson/
http://hamishrickerby.com/2012/01/27/continuous-integration-and-ios/
