### PR TITLE
Make frankified version have different name

### DIFF
--- a/example/CountItOut/CountItOut.xcodeproj/project.pbxproj
+++ b/example/CountItOut/CountItOut.xcodeproj/project.pbxproj
@@ -203,7 +203,6 @@
 		29B97314FDCFA39411CA2CEA /* CustomTemplate */ = {
 			isa = PBXGroup;
 			children = (
-				C9F072E1160C31B500418A5E /* Security.framework */,
 				D603938F135BD1A500116449 /* Frank */,
 				080E96DDFE201D6D7F000001 /* Classes */,
 				29B97315FDCFA39411CA2CEA /* Other Sources */,
@@ -236,6 +235,7 @@
 		29B97323FDCFA39411CA2CEA /* Frameworks */ = {
 			isa = PBXGroup;
 			children = (
+				C9F072E1160C31B500418A5E /* Security.framework */,
 				D603945C135BD22000116449 /* CFNetwork.framework */,
 				1DF5F4DF0D08C38300B7A737 /* UIKit.framework */,
 				1D30AB110D05D00D00671497 /* Foundation.framework */,

--- a/example/EmployeeAdmin/EmployeeAdmin.xcodeproj/project.pbxproj
+++ b/example/EmployeeAdmin/EmployeeAdmin.xcodeproj/project.pbxproj
@@ -282,7 +282,6 @@
 		29B97314FDCFA39411CA2CEA /* CustomTemplate */ = {
 			isa = PBXGroup;
 			children = (
-				C9F072DF160C31AA00418A5E /* Security.framework */,
 				D6A8351D11CDC54B001B8585 /* Frank */,
 				2860E32A111B888700E27156 /* iPad */,
 				2860E324111B887F00E27156 /* iPhone */,
@@ -306,6 +305,7 @@
 		29B97323FDCFA39411CA2CEA /* Frameworks */ = {
 			isa = PBXGroup;
 			children = (
+				C9F072DF160C31AA00418A5E /* Security.framework */,
 				D6A8368211CDC5BA001B8585 /* CFNetwork.framework */,
 				1DF5F4DF0D08C38300B7A737 /* UIKit.framework */,
 				1D30AB110D05D00D00671497 /* Foundation.framework */,

--- a/gem/lib/frank-cucumber/cli.rb
+++ b/gem/lib/frank-cucumber/cli.rb
@@ -176,6 +176,7 @@ module Frank
         existing_bundle_identifier = `/usr/libexec/PlistBuddy -c 'Print :CFBundleIdentifier' Info.plist`.chomp
         new_bundle_identifier = existing_bundle_identifier + '.frankified'
         run %Q|/usr/libexec/PlistBuddy -c 'Set :CFBundleIdentifier #{new_bundle_identifier}' Info.plist|
+        run %Q|/usr/libexec/PlistBuddy -c 'Set :CFBundleDisplayName Frankified' Info.plist|
       end
     end
 


### PR DESCRIPTION
I noticed the new approach to avoid the black screen of death, by changing the bundle ID. I got confused which app was which, now there are two in the simulator, one Frankified and one not... so I used PlistBuddy to also update the bundle display name, so you can tell which one is Frankified.
