### PR TITLE
Allow plugins to register commands

### DIFF
--- a/src/FrankCommandRoute.h
+++ b/src/FrankCommandRoute.h
@@ -21,6 +21,8 @@
 	NSMutableDictionary *_commandDict;
 }
 
++ (FrankCommandRoute *) singleton;
+
 -(void) registerCommand: (id<FrankCommand>)command withName:(NSString *)commandName;
 
 @end

--- a/src/FrankCommandRoute.m
+++ b/src/FrankCommandRoute.m
@@ -17,6 +17,25 @@ extern BOOL frankLogEnabled;
 
 @implementation FrankCommandRoute
 
+
+#pragma mark singleton implementation
+
+static FrankCommandRoute *s_singleton;
+
++ (void)initialize
+{
+    static BOOL initialized = NO;
+    if(!initialized)
+    {
+        initialized = YES;
+        s_singleton = [[FrankCommandRoute alloc] init];
+    }
+}
+
++ (FrankCommandRoute *) singleton{
+	return s_singleton;
+}
+
 - (id) init
 {
 	self = [super init];

--- a/src/FrankServer.m
+++ b/src/FrankServer.m
@@ -41,7 +41,7 @@ static NSUInteger __defaultPort = FRANK_SERVER_PORT;
 		if( ![bundleName hasSuffix:@".bundle"] )
 			bundleName = [bundleName stringByAppendingString:@".bundle"];
 		
-		FrankCommandRoute *frankCommandRoute = [[[FrankCommandRoute alloc] init] autorelease];
+		FrankCommandRoute *frankCommandRoute = [FrankCommandRoute singleton];
 		[frankCommandRoute registerCommand:[[[DumpCommand alloc]init]autorelease] withName:@"dump"];
 		[frankCommandRoute registerCommand:[[[MapOperationCommand alloc]init]autorelease] withName:@"map"];
 		[frankCommandRoute registerCommand:[[[OrientationCommand alloc]init]autorelease] withName:@"orientation"];


### PR DESCRIPTION
A simple change: make the Command route a singleton. This makes it easy for plugins to register new commands.
