### PR TITLE
Make frank-cucumber compatible with ruby 1.8 syntax

### DIFF
--- a/gem/lib/frank-cucumber/rect.rb
+++ b/gem/lib/frank-cucumber/rect.rb
@@ -14,10 +14,10 @@ module Frank module Cucumber
     end
 
     def center
-      OpenStruct.new( 
-                     x: @x.to_f + (@width.to_f/2),
-                     y: @y.to_f + (@height.to_f/2)
-                    )
+      OpenStruct.new({
+        :x => @x.to_f + (@width.to_f/2),
+        :y => @y.to_f + (@height.to_f/2)
+     })
     end
   end
 


### PR DESCRIPTION
With frank-cucumber 1.1.2 you introduced a dependency to ruby 1.9 by using the new hash syntax. I think many users (like me) will run into syntax error because of ruby 1.8 comes with a Mac by default. So my backport of the regarding hash is only a small change to be compatible with ruby 1.8.
