### PR TITLE
Allow setting the target during setup phase from the command line

### DIFF
--- a/gem/lib/frank-cucumber/cli.rb
+++ b/gem/lib/frank-cucumber/cli.rb
@@ -31,6 +31,7 @@ module Frank
     method_option WITHOUT_ASYNC_SOCKET, :type => :boolean
     method_option WITHOUT_LUMBERJACK, :type => :boolean
     method_option :build_configuration, :aliases=>'--conf', :type=>:string, :default => 'Debug'
+    method_option :target, :type=>:string
     def setup
       @libs = %w(Shelley CocoaAsyncSocket CocoaLumberjack CocoaHTTPServer Frank)
       @libsMac = %w(CocoaAsyncSocketMac CocoaLumberjackMac CocoaHTTPServerMac FrankMac)
@@ -42,7 +43,7 @@ module Frank
       @libsMac -= %w(CocoaLumberjackMac) if options[WITHOUT_LUMBERJACK]
       directory ".", "Frank"
 
-      Frankifier.frankify!( File.expand_path('.'), :build_config => options[:build_configuration] )
+      Frankifier.frankify!( File.expand_path('.'), :build_config => options[:build_configuration], :target => options[:target] )
     end
 
     desc "update", "updates the frank server components inside your Frank directory"
@@ -91,7 +92,7 @@ module Frank
       extra_opts = XCODEBUILD_OPTIONS.map{ |o| "-#{o} \"#{options[o]}\"" if options[o] }.compact.join(' ')
 
       # If there is a scheme specified we don't want to inject the default configuration
-      # If there is a configuration specified, we also do not want to inject the default configuration 
+      # If there is a configuration specified, we also do not want to inject the default configuration
       if options['scheme'] || options['configuration']
         separate_configuration_option = ""
       else

--- a/gem/lib/frank-cucumber/frankifier.rb
+++ b/gem/lib/frank-cucumber/frankifier.rb
@@ -13,6 +13,7 @@ class Frankifier
   def initialize( root_dir, options = {} )
     @root = Pathname.new( root_dir )
     @target_build_configuration = options[:build_config]
+    @target_selection = options[:target]
   end
 
   def frankify!
@@ -53,6 +54,8 @@ class Frankifier
 
   def decide_on_target
     targets = @project.targets
+    @target = targets.find { |item| item.name.eql?(@target_selection) } if @target_selection
+    return @target if @target
     @target = case targets.size
     when 0
       raise "Sorry, this project appears to contain no targets. Nothing I can do here."


### PR DESCRIPTION
For easier non-user input command line execution, which would also make the Jenkins integration easier, it would be very useful to specify the target during the setup phase. 
The changes suggested are minimal and localized to cli.rb and frankifier.rb.
