### PR TITLE
Quit warning about one simulator when timeout occurs during launch.

### DIFF
--- a/gem/lib/frank-cucumber/host_scripting.rb
+++ b/gem/lib/frank-cucumber/host_scripting.rb
@@ -29,6 +29,19 @@ module HostScripting
     APPLESCRIPT}
   end
 
+  def quit_double_simulator
+    %x{osascript<<APPLESCRIPT
+      activate application "iPhone Simulator"
+      tell application "System Events"
+        tell process "#{Localize.t(:iphone_simulator)}"
+          if (value of static text 1 of window 1) is "#{Localize.t(:only_one_simulator)}" then
+            click button 1 of window 1
+          end if
+        end tell
+      end tell
+    }
+  end
+
 def simulator_reset_data
   %x{osascript<<APPLESCRIPT
 activate application "iPhone Simulator"

--- a/gem/lib/frank-cucumber/launcher.rb
+++ b/gem/lib/frank-cucumber/launcher.rb
@@ -52,19 +52,17 @@ module Launcher
     end
 
     num_timeouts = 0
-    loop do
-      begin
-        simulator.relaunch
-        wait_for_frank_to_come_up
-        break # if we make it this far without an exception then we're good to move on
-
-      rescue Timeout::Error
-        num_timeouts += 1
-        puts "Encountered #{num_timeouts} timeouts while launching the app."
-        if num_timeouts > 3
-          raise "Encountered #{num_timeouts} timeouts in a row while trying to launch the app." 
-        end
+    begin
+      simulator.relaunch
+      wait_for_frank_to_come_up
+    rescue Timeout::Error
+      num_timeouts += 1
+      puts "Encountered #{num_timeouts} timeouts while launching the app."
+      if num_timeouts > 3
+        raise "Encountered #{num_timeouts} timeouts in a row while trying to launch the app."
       end
+      quit_double_simulator
+      retry
     end
 
   end

--- a/gem/lib/frank-cucumber/localize.yml
+++ b/gem/lib/frank-cucumber/localize.yml
@@ -8,6 +8,7 @@ en:
   simulate_memory_warning: Simulate Memory Warning
   toggle_in_call_status_bar: Toggle In-Call Status Bar
   simulate_hardware_keyboard: Simulate Hardware Keyboard
+  only_one_simulator: Only one iOS Simulator can run at a time.
 
 fr:
   iphone_simulator: Simulateur iOS
@@ -19,6 +20,7 @@ fr:
   simulate_memory_warning: Simuler un avertissement de mémoire
   toggle_in_call_status_bar: Afficher/Masquer la barre d'état d'appel en cour
   simulate_hardware_keyboard: Simuler un clavier matériel
+  only_one_simulator: Un seul Simulateur iOS peut être exécuté à la fois.
 
 de:
   iphone_simulator: iOS-Simulator
@@ -30,6 +32,7 @@ de:
   simulate_memory_warning: Speicherwarnhinweis simulieren
   toggle_in_call_status_bar: Status für eingeh. Anrufe ein/aus
   simulate_hardware_keyboard: Hardware-Tastatur simulieren
+  only_one_simulator: Es kann jeweils nur eine iOS-Simulator-Instanz aktiv sein.
 
 ru:
   iphone_simulator: Симулятор iOS
@@ -41,6 +44,7 @@ ru:
   simulate_memory_warning: Симулировать предупреждение о нехватке памяти
   toggle_in_call_status_bar: Переключить на строку состояния поступающего вызова
   simulate_hardware_keyboard: Симулировать физическую клавиатуру
+  only_one_simulator: Два и более Симуляторов iOS не могут быть запущены одновременно.
 
 zh:
   iphone_simulator: iOS 模拟器
@@ -52,6 +56,7 @@ zh:
   simulate_memory_warning: 模拟内存警告
   toggle_in_call_status_bar: 切换呼叫状态栏
   simulate_hardware_keyboard: 模拟硬件键盘
+  only_one_simulator: 一次只能运行一个“iOS 模拟器”。
 
 ja:
   iphone_simulator: iOSシミュレータ
@@ -63,6 +68,7 @@ ja:
   simulate_memory_warning: メモリ警告をシミュレート
   toggle_in_call_status_bar: 着信ステータスバーを切り替える
   simulate_hardware_keyboard: ハードウェアキーボードをシミュレート
+  only_one_simulator: 実行できるiOSシミュレータは1度に1つのみです。
 
 es:
   iphone_simulator: Simulador iOS
@@ -74,3 +80,4 @@ es:
   simulate_memory_warning: Simular aviso de memoria
   toggle_in_call_status_bar: Activar/Desactivar barra de estado durante llamada
   simulate_hardware_keyboard: Simular teclado físico
+  only_one_simulator: Sólo se puede ejecutar un Simulador iOS a la vez.


### PR DESCRIPTION
For some reason, when starting a second simulator while another one
is already running, a modal dialog appears. The standard "quit" event
will not work.

If after a timeout occurs trying to contact the Frank server, let's
try clicking that button in that modal and see if next time we can
start the simulator normally.

The best way to test this is the following:
1. `open /Applications/Xcode.app/Contents/Applications/iPhone\ Simulator.app` to start a simulator.
2. `/Applications/Xcode.app/Contents/Applications/iPhone\ Simulator.app/Contents/MacOS/iPhone\ Simulator` to try to start a second simulator. This should generate the modal dialog saying that only one iOS Simulator instance can be running at the same time.
3. Close the simulator created in step 1 (not the one with the modal dialog).
4. Run a Frank suite.

If everything is right, after the first “PING FAILED!!!” warning the dialog should be dismissed, and the second try to start the app should work.
