### PR TITLE
Fixed issue #187 - invalid argument conversion in Operation

### DIFF
--- a/src/Operation.m
+++ b/src/Operation.m
@@ -66,32 +66,35 @@
 	NSInvocation *invocation = [NSInvocation invocationWithMethodSignature:signature];
 	[invocation setSelector:_selector];
 	
-	char invocationBuffer[300]; //let's hope we don't get asked to invoke a method with more than 28 arguments.
-	
 	NSInteger index = 2; // Indices 0 and 1 indicate the hidden arguments self and _cmd, respectively
 	for( id arg in _arguments ) {
 		if( [arg isKindOfClass:[NSNumber class]] ){
-			void *buffer = &(invocationBuffer[index*10]);
-			[self castNumber:arg toType:[signature getArgumentTypeAtIndex:index] intoBuffer:buffer];
-			[invocation setArgument:buffer atIndex:index];
-		}else {
+            const char* argumentType = [signature getArgumentTypeAtIndex:index];
+            
+            if ( !strcmp(argumentType, @encode(id)) ) {
+                [invocation setArgument:&arg atIndex:index];
+            } else {
+                char buffer[10];
+                [self castNumber:arg toType:argumentType intoBuffer:buffer];
+                [invocation setArgument:buffer atIndex:index];
+            }
+		} else {
 			[invocation setArgument:&arg atIndex:index];
 		}
 		index++;
 	}
 		 
 	[invocation invokeWithTarget:target];
-
 	
 	const char *returnType = signature.methodReturnType;
 	
 	id returnValue;
-	if( !strcmp(returnType, @encode(void)) )
-		returnValue =  nil;
-	else if( !strcmp(returnType, @encode(id)) ) // retval is an objective c object
-	{
+	if( !strcmp(returnType, @encode(void)) ) {
+		returnValue = nil;
+    }
+	else if( !strcmp(returnType, @encode(id)) ) { // retval is an objective c object
 		[invocation getReturnValue:&returnValue];
-	}else {
+	} else {
 		// handle primitive c types by wrapping them in an NSValue
 		
 		NSUInteger length = [signature methodReturnLength];
@@ -100,19 +103,18 @@
 		
 		// for some reason using [NSValue valueWithBytes:returnType] is creating instances of NSConcreteValue rather than NSValue, so 
 		//I'm fudging it here with case-by-case logic
-		if( !strcmp(returnType, @encode(BOOL)) ) 
-		{
+		if( !strcmp(returnType, @encode(BOOL)) ) {
 			returnValue = [NSNumber numberWithBool:*((BOOL*)buffer)];
-		}else if( !strcmp(returnType, @encode(NSInteger)) )
-		{
+		}else if( !strcmp(returnType, @encode(NSInteger)) ) {
 			returnValue = [NSNumber numberWithInteger:*((NSInteger*)buffer)];
-		}else {
+		} else {
 			returnValue = [NSValue valueWithBytes:buffer objCType:returnType];
 		}
-		//free(buffer); memory leak here, but apparently NSValue doesn't copy the passed buffer, it just stores the pointer
+        
+        free(buffer);
 	}
+    
 	return returnValue;	
 }
-
 
 @end


### PR DESCRIPTION
I fixed the <i>NSNumber</i> => <i>NSNumber</i> conversion bug, made some small code improvements and added the <i>free(buffer)</i> line which was incorrectly commented out (<i>NSValue</i> does copy the buffer).
