### PR TITLE
Add 'project' option to xcodebuild options

### DIFF
--- a/gem/lib/frank-cucumber/cli.rb
+++ b/gem/lib/frank-cucumber/cli.rb
@@ -55,7 +55,7 @@ module Frank
       directory( 'frank_static_resources.bundle', 'Frank/frank_static_resources.bundle', :force => true )
     end
 
-    XCODEBUILD_OPTIONS = %w{workspace scheme target configuration}
+    XCODEBUILD_OPTIONS = %w{workspace project scheme target configuration}
     desc "build", "builds a Frankified version of your native app"
     XCODEBUILD_OPTIONS.each do |option|
       method_option option


### PR DESCRIPTION
Every project has different a different set up. I usually use workspaces and schemes to build my projects, some people use projects and targets.

If the .xcodeproj file isn't in the root of the directory, `xcodebuild` doesn't pick it up automatically. This is the case for me - I never have xcodeproj files in the root of the workspace, because people open them and wonder why the implicit dependencies aren't being built (opening the workspace does this automatically).

I've added the `--project PROJECT_NAME` option to `frank build` in the same way that configuration/scheme/workspace are added.
