### PR TITLE
Optionally specify xcodeproj path for 'frank setup'

### DIFF
--- a/gem/lib/frank-cucumber/cli.rb
+++ b/gem/lib/frank-cucumber/cli.rb
@@ -32,6 +32,7 @@ module Frank
     method_option WITHOUT_LUMBERJACK, :type => :boolean
     method_option :build_configuration, :aliases=>'--conf', :type=>:string, :default => 'Debug'
     method_option :target, :type=>:string
+    method_option :project, :type=>:string
     def setup
       @libs = %w(Shelley CocoaAsyncSocket CocoaLumberjack CocoaHTTPServer Frank)
       @libsMac = %w(CocoaAsyncSocketMac CocoaLumberjackMac CocoaHTTPServerMac FrankMac)
@@ -43,7 +44,7 @@ module Frank
       @libsMac -= %w(CocoaLumberjackMac) if options[WITHOUT_LUMBERJACK]
       directory ".", "Frank"
 
-      Frankifier.frankify!( File.expand_path('.'), :build_config => options[:build_configuration], :target => options[:target] )
+      Frankifier.frankify!( File.expand_path('.'), :build_config => options[:build_configuration], :target => options[:target], :project => options[:project] )
     end
 
     desc "update", "updates the frank server components inside your Frank directory"

--- a/gem/lib/frank-cucumber/frankifier.rb
+++ b/gem/lib/frank-cucumber/frankifier.rb
@@ -14,10 +14,11 @@ class Frankifier
     @root = Pathname.new( root_dir )
     @target_build_configuration = options[:build_config]
     @target_selection = options[:target]
+    load_xcode_proj_option(options[:project])
   end
 
   def frankify!
-    decide_on_project
+    decide_on_project if @project.nil?
     decide_on_target
     report_project_and_target
 
@@ -33,6 +34,17 @@ class Frankifier
   end
 
   private
+  def load_xcode_proj_option(xcodeproj)
+    if xcodeproj
+      unless File.exists?(xcodeproj)
+        raise "Project file '#{xcodeproj}' does not exist. Please specify the relative path."
+      end
+      
+      @xcodeproj_path = Pathname.new(xcodeproj)
+      @project = Xcodeproj::Project.new(@xcodeproj_path)
+    end
+  end
+  
   def decide_on_project
     projects = Pathname.glob( @root+'*.xcodeproj' )
     xcodeproj = case projects.size


### PR DESCRIPTION
Similar to the PR I just sent, I regularly have my xcodeproj files outside the workspace root, which means `frank setup` cannot find them.

I have added a `--project` option to `frank setup` where you can provide the relative path to the xcodeproj file.

In my app:

```
workspace
+ -- want to run `frank setup --project app/app.xcodeproj` from here.
+ app
    + app.xcodeproj
+ Pods
+ other stuff
```

In the case where the --project flag is not specified, it falls back to the existing behaviour.
