### PR TITLE
Smarter testing if a view can be tapped

### DIFF
--- a/lib/LoadableCategory.h
+++ b/lib/LoadableCategory.h
@@ -31,4 +31,4 @@
  *
  * @param UNIQUE_NAME A globally unique name.
  */
-#define MAKE_CATEGORIES_LOADABLE(UNIQUE_NAME) @interface FORCELOAD_##UNIQUE_NAME @end @implementation FORCELOAD_##UNIQUE_NAME @end
+#define MAKE_CATEGORIES_LOADABLE(UNIQUE_NAME) @interface FORCELOAD_##UNIQUE_NAME : NSObject @end @implementation FORCELOAD_##UNIQUE_NAME @end


### PR DESCRIPTION
The current Frank code tests if the touch point is inside the window bounds. I have modified the code to:
1. Check whether user interaction is not disabled for the application (`[UIApplication isIgnoringInteractionEvents]`, common case when switching view controllers)
2. Check whether the view can be actually touched (not overlapped by other views) using `-[UIView hitTest:withEvent:]` method

This is possibly connected to Issue #163 - even if we can't check whether a view is visible, we can check if it can be touched.
