### PR TITLE
If building fails exit immediately with an error code

### DIFF
--- a/gem/lib/frank-cucumber/cli.rb
+++ b/gem/lib/frank-cucumber/cli.rb
@@ -109,6 +109,7 @@ module Frank
 
         run %Q|xcodebuild -xcconfig Frank/frankify.xcconfig #{build_steps} #{extra_opts} #{separate_configuration_option} -sdk iphonesimulator DEPLOYMENT_LOCATION=YES DSTROOT="#{build_output_dir}" FRANK_LIBRARY_SEARCH_PATHS="\\"#{frank_lib_directory}\\""|
       end
+      exit $?.exitstatus if not $?.success?
 
       app = Dir.glob("#{build_output_dir}/*.app").delete_if { |x| x =~ /\/#{app_bundle_name}$/ }
       app = app.first


### PR DESCRIPTION
Currently when executing 'frank build' and if the 'xcodebuild' process fails to build the project the script just keeps on going and eventually exits with a 0 status code. This is bad for example CI systems where failures would be noticed from the exit code. The current behavior marks the build as successful although it's not.

With this patch 'frank build' returns the same error code as the xcodebuild execution
does if it fails.
