### PR TITLE
Fixed "allwindows" screenshot with keyboard

### DIFF
--- a/src/ImageCaptureRoute.m
+++ b/src/ImageCaptureRoute.m
@@ -126,23 +126,27 @@
 
 - (NSObject<HTTPResponse> *) handleRequestForPath: (NSArray *)path withConnection:(RoutingHTTPConnection *)connection{
     
-    if( ![@"screenshot" isEqualToString:[path objectAtIndex:0]] )
+    if (![@"screenshot" isEqualToString:[path objectAtIndex:0]]) {
         return nil;
+    }
+    
+    NSString* pathComponent2 = ([path count] > 1) ? [path objectAtIndex:1] : nil;    
 
-
-    if ( [path count] > 1 && [@"snapshot-all-views" isEqualToString:[path objectAtIndex:1]] ){
+    if ([pathComponent2 isEqualToString:@"snapshot-all-views"]) {
         [self snapshotAllViews];
         return [self generateGenericSuccessResponse];
     }
-
-    if ( [path count] > 1 && [@"view-snapshot" isEqualToString:[path objectAtIndex:1]] ){
+    else if ([pathComponent2 isEqualToString:@"view-snapshot"]) {
         return [self responseWithSnapshotOfViewWithUid:[path objectAtIndex:2] withConnection:connection];
     }
     
 #if TARGET_OS_IPHONE
-    BOOL allWindows = [path count] > 1 && [[path objectAtIndex:1] isEqualToString:@"allwindows"];
     
-    UIImage *screenshot = [UIImage imageFromApplication:allWindows];
+    BOOL allWindows = ([pathComponent2 isEqualToString:@"allwindows"] || [pathComponent2 isEqualToString:@"allwindows-rotated"]);
+    BOOL rotated = ([pathComponent2 isEqualToString:@"rotated"] || [pathComponent2 isEqualToString:@"allwindows-rotated"]);
+    
+    UIImage *screenshot = [UIImage imageFromApplication:allWindows
+                                       resultInPortrait:!rotated];
 #else
     NSImage *screenshot = [NSImage imageFromApplication];
 #endif

--- a/src/UIImage+Frank.h
+++ b/src/UIImage+Frank.h
@@ -11,7 +11,7 @@
 
 @interface UIImage(Frank)
 
-+ (UIImage *)imageFromApplication:(BOOL)allWindows;
++ (UIImage *)imageFromApplication:(BOOL)allWindows resultInPortrait:(BOOL)resultInPortrait;
 - (UIImage *)imageCropedToFrame:(CGRect)cropFrame;
 - (UIImage *)imageMaskedAtFrame:(CGRect)maskFrame;
 

--- a/src/UIImage+Frank.m
+++ b/src/UIImage+Frank.m
@@ -7,20 +7,62 @@
 //
 
 #import "UIImage+Frank.h"
+#import <QuartzCore/QuartzCore.h>
 
 #import "UIView+ImageCapture.h"
 
-
 @implementation UIImage(Frank)
 
-+ (UIImage *) imageFromApplication:(BOOL)allWindows 
-{	
-	UIWindow *keyWindow = [[UIApplication sharedApplication] keyWindow];
-	
-    if (allWindows)
-        return [UIView captureImageOfSize:keyWindow.bounds.size fromViews:[[UIApplication sharedApplication] windows]];
-    else
-        return [keyWindow captureImage];
++ (UIImage *)imageFromApplication:(BOOL)allWindows resultInPortrait:(BOOL)resultInPortrait {
+    UIApplication *application = [UIApplication sharedApplication];
+    NSArray* windows = (allWindows) ? application.windows : [NSArray arrayWithObject:application.keyWindow];
+    
+    UIInterfaceOrientation currentOrientation = application.statusBarOrientation;
+    
+    CGSize size = application.keyWindow.bounds.size;
+
+    if (!resultInPortrait && UIInterfaceOrientationIsLandscape(currentOrientation)) {
+        size = CGSizeMake(size.height, size.width);
+    }
+    
+    UIGraphicsBeginImageContext(size);
+    CGContextRef context = UIGraphicsGetCurrentContext();
+
+    if (!resultInPortrait) {
+        if (currentOrientation == UIInterfaceOrientationLandscapeLeft) {
+            CGContextTranslateCTM(context, size.width / 2.0f, size.height / 2.0f);
+            CGContextRotateCTM(context, (CGFloat) M_PI_2);
+            CGContextTranslateCTM(context, - size.height / 2.0f, - size.width / 2.0f);
+        }
+        else if (currentOrientation == UIInterfaceOrientationLandscapeRight) {
+            CGContextTranslateCTM(context, size.width / 2.0f, size.height / 2.0f);
+            CGContextRotateCTM(context, (CGFloat) -M_PI_2);
+            CGContextTranslateCTM(context, - size.height / 2.0f, - size.width / 2.0f);
+        }
+        else if (currentOrientation == UIInterfaceOrientationPortraitUpsideDown) {
+            CGContextTranslateCTM(context, size.width / 2.0f, size.height / 2.0f);
+            CGContextRotateCTM(context, (CGFloat) M_PI);
+            CGContextTranslateCTM(context, -size.width / 2.0f, -size.height / 2.0f);
+        }
+    }
+        
+    for (UIView *window in windows) {
+        CGContextSaveGState(context);
+        CGContextTranslateCTM(context, window.center.x, window.center.y);
+        CGContextConcatCTM(context, window.transform);
+        CGContextTranslateCTM(context,
+                              - window.bounds.size.width * window.layer.anchorPoint.x,
+                              - window.bounds.size.height * window.layer.anchorPoint.y);
+        
+        [window.layer renderInContext:UIGraphicsGetCurrentContext()];
+        
+        CGContextRestoreGState(context);
+    }
+    
+    UIImage *image = UIGraphicsGetImageFromCurrentImageContext();
+    UIGraphicsEndImageContext();
+    
+    return image;
 }
 
 - (UIImage *)imageCropedToFrame:(CGRect)cropFrame

--- a/src/UIView+ImageCapture.h
+++ b/src/UIView+ImageCapture.h
@@ -10,7 +10,6 @@
 
 @interface UIView (ImageCapture)
 
-+ (UIImage *) captureImageOfSize:(CGSize)size fromViews:(NSArray *)views;
-- (UIImage *) captureImage;
+- (UIImage *)captureImage;
 
 @end

--- a/src/UIView+ImageCapture.m
+++ b/src/UIView+ImageCapture.m
@@ -11,18 +11,15 @@
 
 @implementation UIView (ImageCapture)
 
-+ (UIImage *) captureImageOfSize:(CGSize)size fromViews:(NSArray *)views {
-	UIGraphicsBeginImageContext(size);
-    for (UIView *view in views) {
-        [view.layer renderInContext:UIGraphicsGetCurrentContext()];
-    }
+- (UIImage *)captureImage {
+    UIGraphicsBeginImageContext(self.bounds.size);
+    
+    [self.layer renderInContext:UIGraphicsGetCurrentContext()];
+	
     UIImage *image = UIGraphicsGetImageFromCurrentImageContext();
-    UIGraphicsEndImageContext();	
-	return image;    
-}
-
-- (UIImage *) captureImage{
-    return [UIView captureImageOfSize:self.bounds.size fromViews:[NSArray arrayWithObject:self]];
+    UIGraphicsEndImageContext();
+    
+    return image;
 }
 
 @end


### PR DESCRIPTION
This problem was discussed in the mailing groups 

> screenshot/allwindows returning "mashed-up" view

For reference see http://developer.apple.com/library/ios/#qa/qa1703/_index.html

I don't really like that `screenshot/allwindows` always returns image in the portrait orientation but changing that would break symbiote. I have added `screenshot/allwindows-rotated` which will return a screenshot rotated depending on current screen orientation.
