### PR TITLE
Fix: Incorrect .app frankified if there are multiple app targets built

### DIFF
--- a/gem/lib/frank-cucumber/cli.rb
+++ b/gem/lib/frank-cucumber/cli.rb
@@ -210,6 +210,10 @@ module Frank
       settings
     end
 
+    def build_mac
+      determine_build_patform(options) == :osx
+    end
+
     def xcodebuild_command(options, build_steps)
       extra_opts = XCODEBUILD_OPTIONS.map{ |o| "-#{o} \"#{options[o]}\"" if options[o] }.compact.join(' ')
 
@@ -220,9 +224,7 @@ module Frank
       else
         separate_configuration_option = "-configuration Debug"
       end
-
-      build_mac = determine_build_patform(options) == :osx
-
+      
       if build_mac
         %Q|xcodebuild -xcconfig Frank/frankify.xcconfig #{build_steps} #{extra_opts} #{separate_configuration_option} FRANK_LIBRARY_SEARCH_PATHS="\\"#{frank_lib_directory}\\""|
       else

--- a/gem/lib/frank-cucumber/cli.rb
+++ b/gem/lib/frank-cucumber/cli.rb
@@ -95,11 +95,10 @@ module Frank
       full_product_name = settings[:FULL_PRODUCT_NAME]
       built_products_dir = settings[:BUILT_PRODUCTS_DIR]
       built_product = "#{built_products_dir}/#{full_product_name}"
+      app = File.join(build_output_dir, full_product_name)
 
       FileUtils.mkdir build_output_dir unless File.exists?(build_output_dir)
-      FileUtils.cp_r(built_product, build_output_dir)
-
-      app = File.join(build_output_dir, full_product_name)
+      FileUtils.cp_r("#{built_product}/.", app)
       FileUtils.cp_r("#{app}/.", frankified_app_dir)
 
       if options['mac']

--- a/gem/lib/frank-cucumber/cli.rb
+++ b/gem/lib/frank-cucumber/cli.rb
@@ -97,7 +97,7 @@ module Frank
       built_product = "#{built_products_dir}/#{full_product_name}"
 
       FileUtils.mkdir build_output_dir unless File.exists?(build_output_dir)
-      FileUtils.cp_r(built_product, File.join(build_output_dir, full_product_name))
+      FileUtils.cp_r(built_product, build_output_dir)
 
       app = File.join(build_output_dir, full_product_name)
       FileUtils.cp_r("#{app}/.", frankified_app_dir)

--- a/gem/lib/frank-cucumber/cli.rb
+++ b/gem/lib/frank-cucumber/cli.rb
@@ -54,7 +54,7 @@ module Frank
       end
       directory( 'frank_static_resources.bundle', 'Frank/frank_static_resources.bundle', :force => true )
     end
-    
+
     XCODEBUILD_OPTIONS = %w{workspace scheme target configuration}
     desc "build", "builds a Frankified version of your native app"
     XCODEBUILD_OPTIONS.each do |option|
@@ -204,7 +204,6 @@ module Frank
         settings[key.to_sym] = value
       end
   
-      puts settings
       settings
     end
 

--- a/gem/lib/frank-cucumber/cli.rb
+++ b/gem/lib/frank-cucumber/cli.rb
@@ -95,7 +95,9 @@ module Frank
       full_product_name = settings[:FULL_PRODUCT_NAME]
       built_products_dir = settings[:BUILT_PRODUCTS_DIR]
       built_product = "#{built_products_dir}/#{full_product_name}"
-      FileUtils.cp_r(built_product, build_output_dir)
+
+      FileUtils.mkdir build_output_dir unless File.exists?(build_output_dir)
+      FileUtils.cp_r(built_product, File.join(build_output_dir, full_product_name))
 
       app = File.join(build_output_dir, full_product_name)
       FileUtils.cp_r("#{app}/.", frankified_app_dir)


### PR DESCRIPTION
### Changes

Frankify the app with the correct name, not the first .app directory in the build output dir.

Change from building directly in frankified_build/ to building in Xcode's default location and copying only the app to be frankified into frankified_build/.

Extract logic into xcodebuild_command.
### NB

We have to parse `xcodebuild -showBuildSettings` to get the product name associated with a scheme and the default build directory. Using the xcodeproj gem would be better, but, as noted in previous comments, xcodeproj doesn't support accessing existing schemes from a workspace as much as it does creating them. 

I've been using this fix myself for the last month or so. Just checked it against the Controls example project; seems okay with targets, too.
