### PR TITLE
Support for launching retina and tall devices

### DIFF
--- a/example/Controls/features/launching_simulator.feature
+++ b/example/Controls/features/launching_simulator.feature
@@ -12,3 +12,24 @@ Scenario: Launching in iPad explicitly
 Scenario: Launching in iPhone by default
   When I launch the app
   And I pause briefly for demonstration purposes
+
+Scenario: Launching in Retina iPad explicitly
+  When I launch the app using the retina ipad simulator
+  And I pause briefly for demonstration purposes
+
+Scenario: Launching in Retina iPhone (3.5 inch) explicitly
+  When I launch the app using the retina iphone (3.5 inch) simulator
+  And I pause briefly for demonstration purposes
+
+Scenario: Launching in Retina iPhone (4 inch) explicitly
+  When I launch the app using the retina iphone (4 inch) simulator
+  And I pause briefly for demonstration purposes
+
+Scenario: Launching a device in the iPhone family launches iPhone
+  When I launch the app using the iphone family simulator
+  And I pause briefly for demonstration purposes
+
+Scenario: Launching a device in the iPad family launches iPad
+  When I launch the app using the ipad family simulator
+  And I pause briefly for demonstration purposes
+

--- a/example/Controls/features/launching_simulator.feature
+++ b/example/Controls/features/launching_simulator.feature
@@ -32,4 +32,3 @@ Scenario: Launching a device in the iPhone family launches iPhone
 Scenario: Launching a device in the iPad family launches iPad
   When I launch the app using the ipad family simulator
   And I pause briefly for demonstration purposes
-

--- a/example/Controls/features/step_definitions/launch_steps.rb
+++ b/example/Controls/features/step_definitions/launch_steps.rb
@@ -4,7 +4,7 @@ Given /^I launch the app$/ do
   end
 end
 
-# for backwards compatibility. prefer specifying the device instead of the idiom
+# for backwards compatibility. going forwards, prefer specifying the device instead of the idiom
 Given /^I launch the app using the (iphone|ipad) family simulator$/ do |idiom|
   unless $USING_PHYSICAL_DEVICE
     sdk = nil # request default SDK, which will be the most recent
@@ -14,6 +14,8 @@ end
 
 Given /^I launch the app using the (iphone|ipad|retina iphone \(3.5 inch\)|retina iphone \(4 inch\)|retina ipad) simulator$/ do |device|
   unless $USING_PHYSICAL_DEVICE
+    # The device names in the step definition are defined as constants in SimLauncher::DeviceType. 
+    # Reference a non-retina iPhone as: SimLauncher::DeviceType::IPHONE
     launch_app_with_options APP_BUNDLE_PATH, :device => device
   end
 end

--- a/example/Controls/features/step_definitions/launch_steps.rb
+++ b/example/Controls/features/step_definitions/launch_steps.rb
@@ -15,7 +15,7 @@ end
 Given /^I launch the app using the (iphone|ipad|retina iphone \(3.5 inch\)|retina iphone \(4 inch\)|retina ipad) simulator$/ do |device|
   unless $USING_PHYSICAL_DEVICE
     # The device names in the step definition are defined as constants in SimLauncher::DeviceType. 
-    # Reference a non-retina iPhone as: SimLauncher::DeviceType::IPHONE
+    # Reference a non-retina iPhone as: SimLauncher::DeviceType::Phone
     launch_app_with_options APP_BUNDLE_PATH, :device => device
   end
 end

--- a/example/Controls/features/step_definitions/launch_steps.rb
+++ b/example/Controls/features/step_definitions/launch_steps.rb
@@ -4,9 +4,16 @@ Given /^I launch the app$/ do
   end
 end
 
-Given /^I launch the app using the (iphone|ipad) simulator$/ do |idiom|
+# for backwards compatibility. prefer specifying the device instead of the idiom
+Given /^I launch the app using the (iphone|ipad) family simulator$/ do |idiom|
   unless $USING_PHYSICAL_DEVICE
     sdk = nil # request default SDK, which will be the most recent
     launch_app APP_BUNDLE_PATH, nil, idiom
+  end
+end
+
+Given /^I launch the app using the (iphone|ipad|retina iphone \(3.5 inch\)|retina iphone \(4 inch\)|retina ipad) simulator$/ do |device|
+  unless $USING_PHYSICAL_DEVICE
+    launch_app_with_options APP_BUNDLE_PATH, :device => device
   end
 end

--- a/gem/lib/frank-cucumber/frank_helper.rb
+++ b/gem/lib/frank-cucumber/frank_helper.rb
@@ -358,7 +358,7 @@ module FrankHelper
   def wait_for_frank_to_come_up
     num_consec_successes = 0
     num_consec_failures = 0
-    Timeout.timeout(20) do
+    Timeout.timeout(5) do
       while num_consec_successes <= 6
         if frankly_ping
           num_consec_failures = 0

--- a/gem/lib/frank-cucumber/frank_helper.rb
+++ b/gem/lib/frank-cucumber/frank_helper.rb
@@ -358,7 +358,7 @@ module FrankHelper
   def wait_for_frank_to_come_up
     num_consec_successes = 0
     num_consec_failures = 0
-    Timeout.timeout(5) do
+    Timeout.timeout(20) do
       while num_consec_successes <= 6
         if frankly_ping
           num_consec_failures = 0

--- a/gem/lib/frank-cucumber/launcher.rb
+++ b/gem/lib/frank-cucumber/launcher.rb
@@ -76,8 +76,8 @@ module Launcher
   end
 
   def default_device_for_family( family )
-    SimLauncher::DeviceType::IPHONE if family == SimLauncher::DeviceFamily::IPHONE
-    SimLauncher::DeviceType::IPAD if family == SimLauncher::DeviceFamily::IPAD
+    SimLauncher::DeviceType::Phone if family == SimLauncher::DeviceFamily::Phone
+    SimLauncher::DeviceType::Pad if family == SimLauncher::DeviceFamily::Pad
   end
 end
 end end

--- a/gem/lib/frank-cucumber/launcher.rb
+++ b/gem/lib/frank-cucumber/launcher.rb
@@ -34,6 +34,12 @@ module Launcher
     launch_app_with_options(app_path, :sdk => sdk, :device => default_device_for_family(version))
   end
 
+  # @param [String] app_path the app_path to launch.
+  # @param [Hash] options the options to launch the app with.
+  # @option options [String] :sdk the sdk version. Defaults to latest.
+  # @option options [String] :device the device. Defaults to non-retina iphone.
+  # @see https://github.com/moredip/Sim-Launcher SimLauncher::DeviceType for supported devices. 
+  # @option options [String] :app_args arguments to pass to the app being launched.
   def launch_app_with_options(app_path, options = {})
     @application_path = app_path
     @options = options
@@ -70,7 +76,8 @@ module Launcher
   end
 
   def default_device_for_family( family )
-    family
+    SimLauncher::DeviceType::IPHONE if family == SimLauncher::DeviceFamily::IPHONE
+    SimLauncher::DeviceType::IPAD if family == SimLauncher::DeviceFamily::IPAD
   end
 end
 end end

--- a/gem/lib/frank-cucumber/launcher.rb
+++ b/gem/lib/frank-cucumber/launcher.rb
@@ -7,11 +7,11 @@ module Launcher
   attr_accessor :application_path, :sdk, :version
 
   def simulator_client
-    @simulator_client ||= SimLauncher::Client.new(@application_path, @sdk, @version)
+    @simulator_client ||= SimLauncher::Client.new(@application_path, @options)
   end
 
   def simulator_direct_client
-    @simulator_direct_client ||= SimLauncher::DirectClient.new(@application_path, @sdk, @version)
+    @simulator_direct_client ||= SimLauncher::DirectClient.new(@application_path, @options)
   end
 
   def enforce(app_path, locator = Frank::Cucumber::AppBundleLocator.new)
@@ -31,9 +31,12 @@ module Launcher
   end
 
   def launch_app(app_path, sdk = nil, version = 'iphone')
+    launch_app_with_options(app_path, :sdk => sdk, :device => default_device_for_family(version))
+  end
+
+  def launch_app_with_options(app_path, options = {})
     @application_path = app_path
-    @sdk = sdk
-    @version = version
+    @options = options
 
     enforce(app_path)
 
@@ -64,7 +67,10 @@ module Launcher
       quit_double_simulator
       retry
     end
+  end
 
+  def default_device_for_family( family )
+    family
   end
 end
 end end

--- a/src/DeviceCommand.m
+++ b/src/DeviceCommand.m
@@ -9,6 +9,8 @@
 #import "DeviceCommand.h"
 #import "JSON.h"
 
+// These constants are duplicated with ruby code in gem/lib.
+// Don't change one without changing the other. 
 static NSString * const PadDevice = @"ipad";
 static NSString * const PadRetinaDevice = @"retina ipad";
 

--- a/src/DeviceCommand.m
+++ b/src/DeviceCommand.m
@@ -9,8 +9,7 @@
 #import "DeviceCommand.h"
 #import "JSON.h"
 
-// These constants are duplicated with ruby code in gem/lib.
-// Don't change one without changing the other. 
+// Device Types
 static NSString * const PadDevice = @"ipad";
 static NSString * const PadRetinaDevice = @"retina ipad";
 

--- a/src/DeviceCommand.m
+++ b/src/DeviceCommand.m
@@ -15,13 +15,29 @@
     NSString* device = nil;
     
 #if TARGET_OS_IPHONE
+    BOOL isRetina = ([[UIScreen mainScreen] scale] == 2.0);
+    
     switch ([[UIDevice currentDevice] userInterfaceIdiom]) {
         case UIUserInterfaceIdiomPhone:
-            device = @"iphone";
+            if (isRetina) {
+                BOOL isTall = ( fabs( ( double )[ [ UIScreen mainScreen ] bounds ].size.height - ( double )568 ) < DBL_EPSILON ); // from http://stackoverflow.com/questions/12446990/how-to-detect-iphone-5-widescreen-devices
+                
+                if (isTall) {
+                    device = @"retina iphone (4 inch)";
+                }else{
+                    device = @"retina iphone (3.5 inch)";
+                }
+            }else{
+                device = @"iphone";
+            }
             break;
             
         case UIUserInterfaceIdiomPad:
-            device = @"ipad";
+            if (isRetina) {
+                device = @"retina ipad";
+            }else{
+                device = @"ipad";
+            }
             break;
             
         default:

--- a/src/DeviceCommand.m
+++ b/src/DeviceCommand.m
@@ -9,6 +9,13 @@
 #import "DeviceCommand.h"
 #import "JSON.h"
 
+static NSString * const PadDevice = @"ipad";
+static NSString * const PadRetinaDevice = @"retina ipad";
+
+static NSString * const PhoneDevice = @"iphone";
+static NSString * const PhoneRetina3_5InchDevice = @"retina iphone (3.5 inch)";
+static NSString * const PhoneRetina4InchDevice = @"retina iphone (4 inch)";
+
 @implementation DeviceCommand
 
 - (NSString *) handleCommandWithRequestBody:(NSString *) requestBody {
@@ -23,20 +30,20 @@
                 BOOL isTall = ( fabs( ( double )[ [ UIScreen mainScreen ] bounds ].size.height - ( double )568 ) < DBL_EPSILON ); // from http://stackoverflow.com/questions/12446990/how-to-detect-iphone-5-widescreen-devices
                 
                 if (isTall) {
-                    device = @"retina iphone (4 inch)";
+                    device = PhoneRetina4InchDevice;
                 }else{
-                    device = @"retina iphone (3.5 inch)";
+                    device = PhoneRetina3_5InchDevice;
                 }
             }else{
-                device = @"iphone";
+                device = PhoneDevice;
             }
             break;
             
         case UIUserInterfaceIdiomPad:
             if (isRetina) {
-                device = @"retina ipad";
+                device = PadRetinaDevice;
             }else{
-                device = @"ipad";
+                device = PadDevice;
             }
             break;
             

--- a/src/UIImage+Frank.m
+++ b/src/UIImage+Frank.m
@@ -25,7 +25,7 @@
         size = CGSizeMake(size.height, size.width);
     }
     
-    UIGraphicsBeginImageContext(size);
+    UIGraphicsBeginImageContextWithOptions(size, NO, 0.0);
     CGContextRef context = UIGraphicsGetCurrentContext();
 
     if (!resultInPortrait) {


### PR DESCRIPTION
Enables launching retina and tall devices, alongside proposed changes to Sim-Launcher here: https://github.com/moredip/Sim-Launcher/pull/16.

See #215.

Let me know what you think!
