### PR TITLE
-l frags for Frank and shelly look duplicated

### DIFF
--- a/gem/frank-skeleton/frankify.xcconfig.tt
+++ b/gem/frank-skeleton/frankify.xcconfig.tt
@@ -1,6 +1,6 @@
 INSTALL_PATH = /./
 
-FRANK_CORE_LDFLAGS = -all_load -ObjC -framework CFNetwork -framework Security -lShelley -lFrank <%= @libs.map { |lib| "-l#{lib}" }.join(' ') %>
-FRANK_CORE_MAC_LDFLAGS = -all_load -ObjC -framework CFNetwork -framework Security -lShelleyMac -lFrankMac <%= @libsMac.map { |lib| "-l#{lib}" }.join(' ') %>
+FRANK_CORE_LDFLAGS = -all_load -ObjC -framework CFNetwork -framework Security <%= @libs.map { |lib| "-l#{lib}" }.join(' ') %>
+FRANK_CORE_MAC_LDFLAGS = -all_load -ObjC -framework CFNetwork -framework Security <%= @libsMac.map { |lib| "-l#{lib}" }.join(' ') %>
 
 FRANK_CORE_GCC_PREPROCESSOR_DEFINITIONS_NOT_USED_IN_PRECOMPS = FRANKIFIED

--- a/gem/lib/frank-cucumber/cli.rb
+++ b/gem/lib/frank-cucumber/cli.rb
@@ -37,7 +37,7 @@ module Frank
     method_option :project, :type=>:string
     def setup
       @libs = %w(Shelley CocoaAsyncSocket CocoaLumberjack CocoaHTTPServer Frank)
-      @libsMac = %w(CocoaAsyncSocketMac CocoaLumberjackMac CocoaHTTPServerMac FrankMac)
+      @libsMac = %w(ShelleyMac CocoaAsyncSocketMac CocoaLumberjackMac CocoaHTTPServerMac FrankMac)
       @libs -= %w(CocoaHTTPServer) if options[WITHOUT_SERVER]
       @libsMac -= %w(CocoaHTTPServerMac) if options[WITHOUT_SERVER]
       @libs -= %w(CocoaAsyncSocket) if options[WITHOUT_ASYNC_SOCKET]


### PR DESCRIPTION
Since they are included in `@libs` and `@libsMac`, writing them in `frankify.xcconfig.tt` will result duplications.

I am not sure if writing them in `frankify.xcconfig.tt` and remove them from `@libs` is better.
