### PR TITLE
Implement bonjour and target option for "frank console".

### DIFF
--- a/gem/lib/frank-cucumber/cli.rb
+++ b/gem/lib/frank-cucumber/cli.rb
@@ -202,7 +202,7 @@ module Frank
 
     desc 'console', "launch a ruby console connected to your Frankified app"
     method_option :bonjour, :type => :boolean, :default => false, :aliases => :b, :desc => "find Frank via Bonjour." 
-    method_option :target, :type => :string, :default => false, :aliases => :t, :desc => "target URL for Frank."
+    method_option :server, :type => :string, :default => false, :aliases => :s, :desc => "server URL for Frank."
     def console
       # TODO: check whether app is running (using ps or similar), and launch it if it's not
 
@@ -217,7 +217,7 @@ module Frank
       Frank::Cucumber::FrankHelper.use_shelley_from_now_on
       console = Frank::Console.new
       Frank::Cucumber::FrankHelper.test_on_physical_device_via_bonjour if options[:bonjour]
-      Frank::Cucumber::FrankHelper.server_base_url = options[:target] if options[:target]
+      Frank::Cucumber::FrankHelper.server_base_url = options[:server] if options[:server]
       if console.check_for_running_app
         console.pry
       end

--- a/gem/lib/frank-cucumber/cli.rb
+++ b/gem/lib/frank-cucumber/cli.rb
@@ -201,6 +201,8 @@ module Frank
     end
 
     desc 'console', "launch a ruby console connected to your Frankified app"
+    method_option :bonjour, :type => :boolean, :default => false, :aliases => :b, :desc => "find Frank via Bonjour." 
+    method_option :target, :type => :string, :default => false, :aliases => :t, :desc => "target URL for Frank."
     def console
       # TODO: check whether app is running (using ps or similar), and launch it if it's not
 
@@ -214,6 +216,8 @@ module Frank
 
       Frank::Cucumber::FrankHelper.use_shelley_from_now_on
       console = Frank::Console.new
+      Frank::Cucumber::FrankHelper.test_on_physical_device_via_bonjour if options[:bonjour]
+      Frank::Cucumber::FrankHelper.server_base_url = options[:target] if options[:target]
       if console.check_for_running_app
         console.pry
       end


### PR DESCRIPTION
Hi there.

I was implemented `--bonjour` and `--target=<URL>` options for `frank console`, for testing of the physical device.
- `--bonjour` option, FrankHelper connect to the physical device via bonjour.
- `--target=<URL>` option, FrankHelper connect to the `URL`.
