### PR TITLE
Add command for saving screenshots in the camera roll

### DIFF
--- a/Frank.xcodeproj/project.pbxproj
+++ b/Frank.xcodeproj/project.pbxproj
@@ -71,6 +71,8 @@
 		30E82E3417128AB500E5BC7C /* ResolutionCommand.m in Sources */ = {isa = PBXBuildFile; fileRef = 30E82E3117128AB500E5BC7C /* ResolutionCommand.m */; };
 		30E82E3517128AB500E5BC7C /* ResolutionCommand.m in Sources */ = {isa = PBXBuildFile; fileRef = 30E82E3117128AB500E5BC7C /* ResolutionCommand.m */; };
 		387BFA7D17036DDA007B9F17 /* UISlider+PublicAutomation.m in Sources */ = {isa = PBXBuildFile; fileRef = 387BFA7C17036DDA007B9F17 /* UISlider+PublicAutomation.m */; };
+		400632C717C61767005BAE46 /* SaveScreenshotInCameraRollCommand.h in Headers */ = {isa = PBXBuildFile; fileRef = 400632C517C61767005BAE46 /* SaveScreenshotInCameraRollCommand.h */; };
+		400632C817C61767005BAE46 /* SaveScreenshotInCameraRollCommand.m in Sources */ = {isa = PBXBuildFile; fileRef = 400632C617C61767005BAE46 /* SaveScreenshotInCameraRollCommand.m */; };
 		4C1DD76C12BADFE100E10B8C /* OrientationCommand.m in Sources */ = {isa = PBXBuildFile; fileRef = 4C1DD76812BADFE100E10B8C /* OrientationCommand.m */; };
 		4C1DD76D12BADFE100E10B8C /* OrientationCommand.h in Headers */ = {isa = PBXBuildFile; fileRef = 4C1DD76912BADFE100E10B8C /* OrientationCommand.h */; };
 		4C1DD76E12BADFE100E10B8C /* AppCommand.m in Sources */ = {isa = PBXBuildFile; fileRef = 4C1DD76A12BADFE100E10B8C /* AppCommand.m */; };
@@ -313,6 +315,8 @@
 		30E82E3017128AB500E5BC7C /* ResolutionCommand.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ResolutionCommand.h; sourceTree = "<group>"; };
 		30E82E3117128AB500E5BC7C /* ResolutionCommand.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = ResolutionCommand.m; sourceTree = "<group>"; };
 		387BFA7C17036DDA007B9F17 /* UISlider+PublicAutomation.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "UISlider+PublicAutomation.m"; sourceTree = "<group>"; };
+		400632C517C61767005BAE46 /* SaveScreenshotInCameraRollCommand.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = SaveScreenshotInCameraRollCommand.h; sourceTree = "<group>"; };
+		400632C617C61767005BAE46 /* SaveScreenshotInCameraRollCommand.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = SaveScreenshotInCameraRollCommand.m; sourceTree = "<group>"; };
 		4C1DD76812BADFE100E10B8C /* OrientationCommand.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = OrientationCommand.m; sourceTree = "<group>"; };
 		4C1DD76912BADFE100E10B8C /* OrientationCommand.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = OrientationCommand.h; sourceTree = "<group>"; };
 		4C1DD76A12BADFE100E10B8C /* AppCommand.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = AppCommand.m; sourceTree = "<group>"; };
@@ -699,6 +703,8 @@
 				C189EF1D16BB5A8000F8236D /* VersionCommand.m */,
 				30E82E3017128AB500E5BC7C /* ResolutionCommand.h */,
 				30E82E3117128AB500E5BC7C /* ResolutionCommand.m */,
+				400632C517C61767005BAE46 /* SaveScreenshotInCameraRollCommand.h */,
+				400632C617C61767005BAE46 /* SaveScreenshotInCameraRollCommand.m */,
 			);
 			name = Commands;
 			sourceTree = "<group>";
@@ -866,6 +872,7 @@
 				303CFCE416C80B830004BD05 /* DeviceCommand.h in Headers */,
 				30E82E3217128AB500E5BC7C /* ResolutionCommand.h in Headers */,
 				0626BFAE174300240020B33B /* DumpCommandRoute.h in Headers */,
+				400632C717C61767005BAE46 /* SaveScreenshotInCameraRollCommand.h in Headers */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -1240,6 +1247,7 @@
 				387BFA7D17036DDA007B9F17 /* UISlider+PublicAutomation.m in Sources */,
 				0626BFAF174300240020B33B /* DumpCommandRoute.m in Sources */,
 				3078E33C175417AE0016889C /* NSObject+FrankAutomation.m in Sources */,
+				400632C817C61767005BAE46 /* SaveScreenshotInCameraRollCommand.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/gem/lib/frank-cucumber/core_frank_steps.rb
+++ b/gem/lib/frank-cucumber/core_frank_steps.rb
@@ -112,6 +112,10 @@ Then /^I should not see an element of class "([^\"]*)"$/ do |className|
   element_exists_and_is_not_hidden.should be_false
 end
 
+# -- Save screenshots in the camera roll -- #
+Given /^the device saves (\d+) screenshot(s)? in the camera roll$/ do |number,_|
+  frankly_save_screenshot_in_camera_roll number
+end
 
 # -- Rotate -- #
 Given /^the device is in (a )?(landscape|portrait) orientation$/ do |_,orientation|

--- a/gem/lib/frank-cucumber/frank_helper.rb
+++ b/gem/lib/frank-cucumber/frank_helper.rb
@@ -368,6 +368,14 @@ module FrankHelper
     return Gateway.evaluate_frankly_response( res, "set_orientation #{orientation}" )
   end
 
+  # takes an screenshot and saves it an specific number of times in the camera roll.
+  # @param number the number of times the screenshot will be saved.
+  # @return always success, because there is no way of knowing wether the screenshots were succesfully saved or not.
+  def frankly_save_screenshot_in_camera_roll(number)
+    res = frank_server.send_post( 'save_screenshot_in_camera_roll', number )
+    return Gateway.evaluate_frankly_response( res, "save_screenshot_in_camera_roll #{number}" )
+  end
+
   # @return [Boolean] Does the device running the application have accessibility enabled.
   # If accessibility is not enabled then a lot of Frank functionality will not work.
   def frankly_is_accessibility_enabled

--- a/src/FrankServer.m
+++ b/src/FrankServer.m
@@ -28,6 +28,7 @@
 #import "OrientationCommand.h"
 #import "LocationCommand.h"
 #import "IOSKeyboardCommand.h"
+#import "SaveScreenshotInCameraRollCommand.h"
 #else
 #import "OSXKeyboardCommand.h"
 #endif
@@ -73,6 +74,7 @@ static NSUInteger __defaultPort = FRANK_SERVER_PORT;
         [frankCommandRoute registerCommand:[[[OrientationCommand alloc]init]autorelease] withName:@"orientation"];
         [frankCommandRoute registerCommand:[[[LocationCommand alloc]init]autorelease] withName:@"location"];
         [frankCommandRoute registerCommand:[[[IOSKeyboardCommand alloc] init]autorelease] withName:@"type_into_keyboard"];
+        [frankCommandRoute registerCommand:[[[SaveScreenshotInCameraRollCommand alloc] init]autorelease] withName:@"save_screenshot_in_camera_roll"];
 #else
         [frankCommandRoute registerCommand:[[[SuccessCommand alloc]init]autorelease] withName:@"orientation"];
         [frankCommandRoute registerCommand:[[[SuccessCommand alloc]init]autorelease] withName:@"location"];

--- a/src/SaveScreenshotInCameraRollCommand.h
+++ b/src/SaveScreenshotInCameraRollCommand.h
@@ -1,0 +1,15 @@
+//
+//  SaveScreenshotInCameraRollCommand.h
+//  Frank
+//
+//  Created by Sergio Padrino on 22/08/13.
+//
+//
+
+#import <Foundation/Foundation.h>
+
+#import "FrankCommandRoute.h"
+
+@interface SaveScreenshotInCameraRollCommand : NSObject <FrankCommand>
+
+@end

--- a/src/SaveScreenshotInCameraRollCommand.m
+++ b/src/SaveScreenshotInCameraRollCommand.m
@@ -1,0 +1,62 @@
+//
+//  SaveScreenshotInCameraRollCommand.m
+//  Frank
+//
+//  Created by Sergio Padrino on 22/08/13.
+//
+//
+
+#import "SaveScreenshotInCameraRollCommand.h"
+
+#import "FranklyProtocolHelper.h"
+#import "UIImage+Frank.h"
+
+@interface SaveScreenshotInCameraRollCommand ()
+
+@property (nonatomic, assign) NSUInteger numberOfPhotos;
+@property (nonatomic, retain) UIImage *screenshot;
+
+@end
+
+@implementation SaveScreenshotInCameraRollCommand
+
+- (void)dealloc
+{
+    [_screenshot release];
+    
+    [super dealloc];
+}
+
+- (NSString *)handleCommandWithRequestBody:(NSString *)requestBody {
+    self.numberOfPhotos = [requestBody integerValue];
+
+    self.screenshot = [UIImage imageFromApplication:YES
+                                   resultInPortrait:UIDeviceOrientationIsPortrait([[UIDevice currentDevice] orientation])];
+
+    // This code is running in the main thread and UIImageWriteToSavedPhotosAlbum also calls its callback in the main
+    // thread. Therefore, it's impossible to make this process completely synchronous as needed (waiting for all the
+    // images to be saved and then return the results), so all we can do is start a chain of calls for saving the images
+    // and hope for the app to live long enough so that all the images are written in the camera roll.
+    [self saveScreenshotInPhotosAlbum];
+
+    return [FranklyProtocolHelper generateSuccessResponseWithoutResults];
+}
+
+- (void)image:(UIImage *)image didFinishSavingWithError:(NSError *)error contextInfo:(void *)contextInfo {
+    self.numberOfPhotos -= 1;
+
+    // Continue saving images until all have been saved
+    if (self.numberOfPhotos > 0) {
+        [self saveScreenshotInPhotosAlbum];
+    }
+    else {
+        self.screenshot = nil;
+    }
+}
+
+- (void)saveScreenshotInPhotosAlbum
+{
+    UIImageWriteToSavedPhotosAlbum(self.screenshot, self, @selector(image:didFinishSavingWithError:contextInfo:), nil);
+}
+
+@end


### PR DESCRIPTION
Hi,

@drodriguez and I've added a command for populating with photos the camera roll of an iOS device/simulator. We needed this in order to test our app properly, because our acceptance tests reset the simulator data before launching the app, assuring a clean environment for each scenario, but losing any photos we may have in the camera roll.

Therefore, we thought the cleanest way of putting images in the camera roll was adding a customised step for Frank so that each test could have different number of photos in the camera roll for different purposes.

Usage: just add the following step to an scenario

``` cucumber
Given the device saves 7 screenshots in the camera roll
```

We think this command may be useful for more people, so if you like it feel free to merge it. If you think it needs some changes before merging, just tell me and I'll do my best :)

Thanks in advance!
