### PR TITLE
Fix reset simulator ios7

### DIFF
--- a/gem/lib/frank-cucumber/host_scripting.rb
+++ b/gem/lib/frank-cucumber/host_scripting.rb
@@ -48,7 +48,7 @@ activate application "iPhone Simulator"
 tell application "System Events"
   click menu item 5 of menu 1 of menu bar item 2 of menu bar 1 of process "#{Localize.t(:iphone_simulator)}"
   delay 0.5
-  click button 2 of window 1 of process "#{Localize.t(:iphone_simulator)}"
+  click button "#{Localize.t(:iphone_simulator_reset)}" of window 1 of process "#{Localize.t(:iphone_simulator)}"
 end tell
   APPLESCRIPT} 
 end

--- a/gem/lib/frank-cucumber/localize.yml
+++ b/gem/lib/frank-cucumber/localize.yml
@@ -1,5 +1,6 @@
 en:
   iphone_simulator: iPhone Simulator
+  iphone_simulator_reset: Reset
   hardware: Hardware
   home: Home
   rotate_left: Rotate Left

--- a/gem/lib/frank-cucumber/localize.yml
+++ b/gem/lib/frank-cucumber/localize.yml
@@ -13,6 +13,7 @@ en:
 
 fr:
   iphone_simulator: Simulateur iOS
+  iphone_simulator_reset: Reset
   hardware: Matériel
   home: Écran d’accueil
   rotate_left: Rotation à gauche
@@ -25,6 +26,7 @@ fr:
 
 de:
   iphone_simulator: iOS-Simulator
+  iphone_simulator_reset: Reset
   hardware: Hardware
   home: Home
   rotate_left: Links drehen
@@ -37,6 +39,7 @@ de:
 
 ru:
   iphone_simulator: Симулятор iOS
+  iphone_simulator_reset: Reset
   hardware: Аппаратура
   home: Экран «Домой»
   rotate_left: Повернуть влево
@@ -49,6 +52,7 @@ ru:
 
 zh:
   iphone_simulator: iOS 模拟器
+  iphone_simulator_reset: Reset
   hardware: 硬件
   home: 首页
   rotate_left: 向左旋转
@@ -61,6 +65,7 @@ zh:
 
 ja:
   iphone_simulator: iOSシミュレータ
+  iphone_simulator_reset: Reset
   hardware: ハードウェア
   home: ホーム
   rotate_left: 反時計回りに回転
@@ -73,6 +78,7 @@ ja:
 
 es:
   iphone_simulator: Simulador iOS
+  iphone_simulator_reset: Reset
   hardware: Hardware
   home: Inicio
   rotate_left: Girar a la izquierda
@@ -85,6 +91,7 @@ es:
 
 it:
   iphone_simulator: Simulatore iOS
+  iphone_simulator_reset: Reset
   hardware: Hardware
   home: Home
   rotate_left: Ruota a sinistra


### PR DESCRIPTION
Under iOS 7 (or just Xcode 5 dev tools?), the "Reset Content and Settings" in the iOS simulator changed which button was the default, which broke the existing Applescript for tapping these buttons.

I have updated the applescript to identify the button by label, so the order or default is no longer important.

There are placeholders for languages other than english, which will need to be filled in.
