### PR TITLE
Setting ONLY_ACTIVE_ARCH=NO when compiling on command line

### DIFF
--- a/gem/lib/frank-cucumber/cli.rb
+++ b/gem/lib/frank-cucumber/cli.rb
@@ -133,7 +133,7 @@ module Frank
       else
         extra_opts += " -arch #{options['arch']}"
 
-        run %Q|xcodebuild -xcconfig #{xcconfig_file} #{build_steps} #{extra_opts} #{separate_configuration_option} -sdk iphonesimulator DEPLOYMENT_LOCATION=YES DSTROOT="#{build_output_dir}" FRANK_LIBRARY_SEARCH_PATHS="#{frank_lib_search_paths}" #{xcodebuild_args}|
+        run %Q|xcodebuild -xcconfig #{xcconfig_file} #{build_steps} #{extra_opts} #{separate_configuration_option} -sdk iphonesimulator ONLY_ACTIVE_ARCH=NO DEPLOYMENT_LOCATION=YES DSTROOT="#{build_output_dir}" FRANK_LIBRARY_SEARCH_PATHS="#{frank_lib_search_paths}" #{xcodebuild_args}|
       end
       exit $?.exitstatus if not $?.success?
 


### PR DESCRIPTION
In the past, I've always specified `ONLY_ACTIVE_ARCH=NO` in my xcconfig files for debug builds, so that they would build correctly on the command line.

_Xcode 5_ complains about this and wants to set `ONLY_ACTIVE_ARCH=YES` for performance reasons. I tend to agree, since I build and run from Xcode much more often than I run the frank build from the command line.

I set it here where we call the xcodebuild command rather than in the `frankify.xcconfig` as I seem to remember having problems with dependent projects not building properly when I used an xcconfig as it is applies the settings all the way down the xcodeproj dependency chain.
