### PR TITLE
Pass all windows to selector engines

### DIFF
--- a/Frank.xcodeproj/project.pbxproj
+++ b/Frank.xcodeproj/project.pbxproj
@@ -527,8 +527,10 @@
 				0867D69AFE84028FC02AAC07 /* Frameworks */,
 				034768DFFF38A50411DB9C8B /* Products */,
 			);
+			indentWidth = 4;
 			name = Frank;
 			sourceTree = "<group>";
+			tabWidth = 4;
 		};
 		0867D69AFE84028FC02AAC07 /* Frameworks */ = {
 			isa = PBXGroup;

--- a/src/SelectorEngineRegistry.h
+++ b/src/SelectorEngineRegistry.h
@@ -19,7 +19,7 @@
 - (NSArray *) selectViewsWithSelector:(NSString *)selector;
 
 /* If a selector engine implements this method, it should return all matching views in
- * any of the windows provided.
+ * any of the windows provided. Currently only supported on iOS.
  */
 - (NSArray *) selectViewsWithSelector:(NSString *)selector inWindows:(NSArray *)windows;
 

--- a/src/SelectorEngineRegistry.h
+++ b/src/SelectorEngineRegistry.h
@@ -10,7 +10,18 @@
 
 @protocol SelectorEngine <NSObject>
 
+@optional
+
+/* Multi-window behaviour for selector engines that only implement this method is
+ * undefined. If an engine supports querying across multiple windows, it should
+ * implement the below method instead.
+ */
 - (NSArray *) selectViewsWithSelector:(NSString *)selector;
+
+/* If a selector engine implements this method, it should return all matching views in
+ * any of the windows provided.
+ */
+- (NSArray *) selectViewsWithSelector:(NSString *)selector inWindows:(NSArray *)windows;
 
 @end
 

--- a/src/SelectorEngineRegistry.m
+++ b/src/SelectorEngineRegistry.m
@@ -7,6 +7,7 @@
 //
 
 #import "SelectorEngineRegistry.h"
+#import "UIApplication+FrankAutomation.h"
 
 static NSMutableDictionary *s_engines;
 
@@ -25,8 +26,15 @@ static NSMutableDictionary *s_engines;
     if( !engine ){
         [NSException raise:@"unrecognized engine" format:@"engine named '%@' hasn't been registered with the SelectorEngineRegistry", engineName];
     }
-    
-    return [engine selectViewsWithSelector:selector];
+    if ([engine respondsToSelector:@selector(selectViewsWithSelector:inWindows:)]) {
+        return [engine selectViewsWithSelector:selector inWindows:[[UIApplication sharedApplication] FEX_windows]];
+    }
+    else if ([engine respondsToSelector:@selector(selectViewsWithSelector:)]) {
+        return [engine selectViewsWithSelector:selector];
+    }
+    else {
+        [NSException raise:@"Engine error" format:@"engine named '%@' does not implement the SelectorEngine protocol", engineName];
+    }
 }
 
 + (NSArray *)getEngineNames {

--- a/src/SelectorEngineRegistry.m
+++ b/src/SelectorEngineRegistry.m
@@ -35,6 +35,7 @@ static NSMutableDictionary *s_engines;
     else {
         [NSException raise:@"Engine error" format:@"engine named '%@' does not implement the SelectorEngine protocol", engineName];
     }
+    return nil;
 }
 
 + (NSArray *)getEngineNames {

--- a/src/SelectorEngineRegistry.m
+++ b/src/SelectorEngineRegistry.m
@@ -7,7 +7,10 @@
 //
 
 #import "SelectorEngineRegistry.h"
+
+#if TARGET_OS_IPHONE
 #import "UIApplication+FrankAutomation.h"
+#endif
 
 static NSMutableDictionary *s_engines;
 
@@ -26,12 +29,18 @@ static NSMutableDictionary *s_engines;
     if( !engine ){
         [NSException raise:@"unrecognized engine" format:@"engine named '%@' hasn't been registered with the SelectorEngineRegistry", engineName];
     }
+#if TARGET_OS_IPHONE
     if ([engine respondsToSelector:@selector(selectViewsWithSelector:inWindows:)]) {
         return [engine selectViewsWithSelector:selector inWindows:[[UIApplication sharedApplication] FEX_windows]];
     }
     else if ([engine respondsToSelector:@selector(selectViewsWithSelector:)]) {
         return [engine selectViewsWithSelector:selector];
     }
+#else
+    if ([engine respondsToSelector:@selector(selectViewsWithSelector:)]) {
+        return [engine selectViewsWithSelector:selector];
+    }
+#endif
     else {
         [NSException raise:@"Engine error" format:@"engine named '%@' does not implement the SelectorEngine protocol", engineName];
     }


### PR DESCRIPTION
This extends the selector engine protocol to support the passing of an array of windows in which the selector engine should attempt to match views.

This makes it possible for selector engines to implement multi-window support without needing to know anything about the FEX_windows category method.

I'm working on a pull request for Igor to support this; Shelley would need the same, but it's backwards compatible.

Perhaps consider deprecating the old method?
