### PR TITLE
Image capture crashes on iOS7

### DIFF
--- a/src/UIImage+Frank.m
+++ b/src/UIImage+Frank.m
@@ -56,7 +56,13 @@
                               - window.bounds.size.width * window.layer.anchorPoint.x,
                               - window.bounds.size.height * window.layer.anchorPoint.y);
         
-        [window.layer.presentationLayer renderInContext:UIGraphicsGetCurrentContext()];
+        // iOS7 has a much more efficient means of capturing the current view hierarchy
+        if ([window respondsToSelector:@selector(drawViewHierarchyInRect:afterScreenUpdates:)]) {
+            [window drawViewHierarchyInRect:window.bounds afterScreenUpdates:YES];
+        }
+        else {
+            [window.layer.presentationLayer renderInContext:UIGraphicsGetCurrentContext()];
+        }
         
         CGContextRestoreGState(context);
     }


### PR DESCRIPTION
I'm still investigating this, but I'm seeing issues where image capture at the end of each of my tests was causing the app to crash.

Unsure if this is a problem isolated to my app or not and so far I've only seen this on our CI build slave. Here's a backtrace:

```
Thread 0 Crashed:: Dispatch queue: com.apple.main-thread
0   WebCore                             0x072671bc -[TileHostLayer renderInContext:] + 44
1   QuartzCore                          0x01a61646 -[CALayer _renderSublayersInContext:] + 413
2   QuartzCore                          0x01a5fb8c -[CALayer renderInContext:] + 1483
3   QuartzCore                          0x01a61646 -[CALayer _renderSublayersInContext:] + 413
4   QuartzCore                          0x01a5fb8c -[CALayer renderInContext:] + 1483
5   QuartzCore                          0x01a61646 -[CALayer _renderSublayersInContext:] + 413
6   QuartzCore                          0x01a5fb8c -[CALayer renderInContext:] + 1483
7   QuartzCore                          0x01a61646 -[CALayer _renderSublayersInContext:] + 413
8   QuartzCore                          0x01a5fb8c -[CALayer renderInContext:] + 1483
9   QuartzCore                          0x01a61646 -[CALayer _renderSublayersInContext:] + 413
10  QuartzCore                          0x01a5fb8c -[CALayer renderInContext:] + 1483
11  CAN                                 0x0016e12f +[UIImage(Frank) imageFromApplication:resultInPortrait:] + 1520 (UIImage+Frank.m:61)
12  CAN                                 0x0016eaf0 -[ImageCaptureRoute handleRequestForPath:withConnection:] + 445 (ImageCaptureRoute.m:150)
13  CAN                                 0x0016a536 __53-[RequestRouter handleRequestForPath:withConnection:]_block_invoke + 53 (RequestRouter.m:68)
14  libdispatch.dylib                   0x03382444 _dispatch_barrier_sync_f_slow_invoke + 71
15  libdispatch.dylib                   0x033934b0 _dispatch_client_callout + 14
16  libdispatch.dylib                   0x03381766 _dispatch_main_queue_callback_4CF + 340
17  CoreFoundation                      0x039afa5e __CFRUNLOOP_IS_SERVICING_THE_MAIN_DISPATCH_QUEUE__ + 14
18  CoreFoundation                      0x038f072b __CFRunLoopRun + 1963
19  CoreFoundation                      0x038efb33 CFRunLoopRunSpecific + 467
20  CoreFoundation                      0x038ef94b CFRunLoopRunInMode + 123
21  GraphicsServices                    0x03e9c9d7 GSEventRunModal + 192
22  GraphicsServices                    0x03e9c7fe GSEventRun + 104
23  UIKit                               0x01c9a94b UIApplicationMain + 1225
```

I'll update this issue as I get more information.
