### PR TITLE
Update UIImage+Frank.m

### DIFF
--- a/src/UIImage+Frank.m
+++ b/src/UIImage+Frank.m
@@ -56,7 +56,7 @@
                               - window.bounds.size.width * window.layer.anchorPoint.x,
                               - window.bounds.size.height * window.layer.anchorPoint.y);
         
-        [window.layer.presentationLayer renderInContext:UIGraphicsGetCurrentContext()];
+        [window.layer renderInContext:UIGraphicsGetCurrentContext()];
         
         CGContextRestoreGState(context);
     }


### PR DESCRIPTION
Fix for crash on screenshot issue on iOS7 (issue #252
Image capture crashes on iOS7), revert to using layer instead of presentationLayer.
