### PR TITLE
Fix applescript execution issue (System Events reports error) with OS X 10.9 Mavericks

### DIFF
--- a/gem/lib/frank-cucumber/host_scripting.rb
+++ b/gem/lib/frank-cucumber/host_scripting.rb
@@ -59,7 +59,7 @@ end
     %x{osascript<<APPLESCRIPT
 activate application "iPhone Simulator"
 tell application "System Events"
-	click menu item "#{menu_label}" of menu "#{Localize.t(:hardware)}" of menu bar of process "#{Localize.t(:iphone_simulator)}"
+	click menu item "#{menu_label}" of menu "#{Localize.t(:hardware)}" of menu bar 1 of process "#{Localize.t(:iphone_simulator)}"
 end tell
   APPLESCRIPT}  
   end


### PR DESCRIPTION
Hello,

Running frank under OS X 10.9 I would receive the following error when invoking `press_home_on_simulator`:

```
71:158: execution error: System Events got an error: menu item "Home" of menu "Hardware" of menu bar of process "iPhone Simulator" doesn’t understand the “click” message. (-1708)
```

Specifying `menu bar 1` instead of `menu bar` seems to have resolved the issue.

Thanks,
James
