### PR TITLE
Give a better error message if the accessibility check fails because there is no UI window

### DIFF
--- a/gem/lib/frank-cucumber/frank_helper.rb
+++ b/gem/lib/frank-cucumber/frank_helper.rb
@@ -60,13 +60,13 @@ module FrankHelper
     else
       return '"'
     end
+  end
 
   # Specify ip address to run on
   def test_on_physical_device_with_ip(ip_address)
-      @server_base_url = ip_address
-      raise 'IP Address is incorrect' unless @server_base_url.match(%r{\b\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}\b})
-      puts "Running on Frank server #{@server_base_url}"
-    end
+    @server_base_url = ip_address
+    raise 'IP Address is incorrect' unless @server_base_url.match(%r{\b\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}\b})
+    puts "Running on Frank server #{@server_base_url}"
   end
 
   #@api private
@@ -372,6 +372,11 @@ module FrankHelper
   # If accessibility is not enabled then a lot of Frank functionality will not work.
   def frankly_is_accessibility_enabled
     res = frank_server.send_get( 'accessibility_check' )
+
+    if JSON.parse( res )['key_window_exists'] == 'false'
+      raise "You must have a UIWindow"
+    end
+
     JSON.parse( res )['accessibility_enabled'] == 'true'
   end
 

--- a/src/AccessibilityCheckCommand.m
+++ b/src/AccessibilityCheckCommand.m
@@ -34,9 +34,11 @@
 #endif // TARGET_OS_IPHONE
 
 - (NSString *)handleCommandWithRequestBody:(NSString *)requestBody {
+    NSString *boolWindowString = ([[UIApplication sharedApplication] keyWindow] != nil ? @"true" : @"false");
 	NSString *boolString = ([self accessibilitySeemsToBeTurnedOn] ? @"true" : @"false");
-	NSDictionary *response = [NSDictionary dictionaryWithObject:boolString
-														forKey:@"accessibility_enabled"];
+    NSDictionary *response = [NSDictionary dictionaryWithObjects:[NSArray arrayWithObjects:boolString, boolWindowString, nil]
+                                                         forKeys:[NSArray arrayWithObjects:@"accessibility_enabled", @"key_window_exists", nil]];
+
 	return TO_JSON(response);
 }
 


### PR DESCRIPTION
This happened:
http://fluffyjack.roon.io/always-check-the-source-code
