### PR TITLE
Allowing UIAlertViews be queryable in iOS7.

### DIFF
--- a/gem/lib/frank-cucumber/core_frank_steps.rb
+++ b/gem/lib/frank-cucumber/core_frank_steps.rb
@@ -80,7 +80,7 @@ Then /^I should see an alert view with the message "([^\"]*)"$/ do |expected_mar
 end
 
 Then /^I should not see an alert view$/ do
-  if ENV['LAST_IOS_VERSION'].to_f >= 7.0
+  if frankly_os_version.to_f >= 7.0
     check_element_does_not_exist( '_UIModalItemRepresentationView' )
   else
     check_element_does_not_exist( 'alertView' )

--- a/gem/lib/frank-cucumber/core_frank_steps.rb
+++ b/gem/lib/frank-cucumber/core_frank_steps.rb
@@ -66,7 +66,11 @@ Then /I should not see the following:/ do |table|
 end
 
 Then /^I should see an alert view titled "([^\"]*)"$/ do |expected_mark|
-  values = frankly_map( 'alertView', 'title')
+  if frankly_os_version.to_f >= 7.0
+    values = frankly_map( "view:'_UIModalItemRepresentationView' label", 'text')
+  else
+    values = frankly_map( 'alertView', 'title')
+  end
   values.should include(expected_mark)
 end
 
@@ -76,7 +80,11 @@ Then /^I should see an alert view with the message "([^\"]*)"$/ do |expected_mar
 end
 
 Then /^I should not see an alert view$/ do
-  check_element_does_not_exist( 'alertView' )
+  if ENV['LAST_IOS_VERSION'].to_f >= 7.0
+    check_element_does_not_exist( '_UIModalItemRepresentationView' )
+  else
+    check_element_does_not_exist( 'alertView' )
+  end
 end
 
 Then /^I should see an element of class "([^\"]*)" with name "([^\"]*)" with the following labels: "([^\"]*)"$/ do |className, classLabel, listOfLabels|

--- a/gem/lib/frank-cucumber/core_frank_steps.rb
+++ b/gem/lib/frank-cucumber/core_frank_steps.rb
@@ -81,7 +81,7 @@ end
 
 Then /^I should not see an alert view$/ do
   if frankly_os_version.to_f >= 7.0
-    check_element_does_not_exist( '_UIModalItemRepresentationView' )
+    check_element_does_not_exist( '_UIModalItemRepresentationView' ) 
   else
     check_element_does_not_exist( 'alertView' )
   end


### PR DESCRIPTION
Second try at allowing UIAlertViews be queryable in iOS7. Please ignore PR number 259.
