### PR TITLE
fix for #198 (cannot handle socket)

### DIFF
--- a/gem/lib/frank-cucumber/cli.rb
+++ b/gem/lib/frank-cucumber/cli.rb
@@ -136,6 +136,12 @@ module Frank
       exit $?.exitstatus if not $?.success?
 
       app = Dir.glob("#{build_output_dir}/*.app").delete_if { |x| x =~ /\/#{app_bundle_name}$/ }
+
+      # when building with Cocoapods, the app is built in an "Applications" subdirectory
+      if app.empty?
+        app = Dir.glob("#{build_output_dir}/Applications/*.app").delete_if { |x| x =~ /\/#{app_bundle_name}$/ }
+      end
+
       app = app.first
       FileUtils.cp_r("#{app}/.", frankified_app_dir)
 


### PR DESCRIPTION
I encountered #198 while frankifying a cocoapods app and resolved it with this change. I'm new to Frank and not sure where this fits in, but I figure this workaround seems harmless enough that you might want to include it.
